### PR TITLE
Add workflow to test `cpi-count` on EC2 runners

### DIFF
--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -27,13 +27,13 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
-          ec2-image-id: ami-006ec002b74f6c066 # Amazon Linux 2 in us-east-2
+          ec2-image-id: ami-0884d2865dbe9de4b # Ubuntu 22.04 LTS in us-east-2
           ec2-instance-type: t3.micro
           subnet-id: ${{ secrets.AWS_SUBNET_ID }}
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           pre-runner-script: |
-            sudo yum update -y && \
-            sudo yum install docker git libicu just -y
+            sudo apt update -y && \
+            sudo apt install docker git libicu just -y
             sudo systemctl enable docker
           aws-resource-tags: >
             [

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -47,6 +47,8 @@ jobs:
               {"Key": "Actor", "Value": "${{ github.actor }}"}
             ]
 
+  # We set `perf_event_paranoid=0` so that we can run the cpi-count program and
+  # tests without elevated privileges.
   ensure-perf-event-paranoid:
     name: Ensure `perf_event_paranoid` is set
     needs: start-runner
@@ -74,10 +76,13 @@ jobs:
     permissions:
       contents: read
     steps:
+      # It seems that when using a self-hosted runner with an Ubuntu image,
+      # the $HOME directory is not created/maintained. We manually create it
+      # here because the `go` installation requires a valid $HOME directory
+      # for several `go` environment variables.
       - name: Create home directory
         run: |
           mkdir -p /home/runner
-          chmod -R 777 /home/runner
           echo "HOME=/home/runner" >> $GITHUB_ENV
       - name: Print environment variables
         run: |
@@ -93,7 +98,6 @@ jobs:
           mv cmd/cpi-count/* .
           rm -rf cmd
           ls -al
-
       - name: Install `go`
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -28,6 +28,11 @@ jobs:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
           ec2-image-id: ami-0884d2865dbe9de4b # Ubuntu 22.04 LTS in us-east-2
+          # See this Intel VTune documentation that lists the instances that support
+          # hardware events:
+          # https://www.intel.com/content/www/us/en/developer/articles/technical/intel-vtune-amplifier-functionality-on-aws-instances.html
+          # The cheapest instance is probably going to be c5.9xlarge, but it requires
+          # submitting a request to AWS for a vCPU quota increase.
           ec2-instance-type: m5zn.6xlarge
           subnet-id: ${{ secrets.AWS_SUBNET_ID }}
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -31,9 +31,7 @@ jobs:
           # See this Intel VTune documentation that lists the instances that support
           # hardware events:
           # https://www.intel.com/content/www/us/en/developer/articles/technical/intel-vtune-amplifier-functionality-on-aws-instances.html
-          # The cheapest instance is probably going to be c5.9xlarge, but it requires
-          # submitting a request to AWS for a vCPU quota increase.
-          ec2-instance-type: m5zn.6xlarge
+          ec2-instance-type: c5.9xlarge
           subnet-id: ${{ secrets.AWS_SUBNET_ID }}
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           pre-runner-script: |

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -66,7 +66,7 @@ jobs:
 
   stop-runner:
     name: Stop EC2 runner
-    needs: [start-runner, do-job]
+    needs: [start-runner, run-tests]
     runs-on: ubuntu-latest
     if: always() # Run even if previous jobs fail
     steps:

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: tverghis/ec2-github-runner@7170053c36b2928213de1cf2303ac85059dadeee
+        uses: machulav/ec2-github-runner@v2
         with:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
@@ -51,7 +51,6 @@ jobs:
               {"Key": "Branch", "Value": "${{ github.ref_name }}"},
               {"Key": "Actor", "Value": "${{ github.actor }}"}
             ]
-          market-type: spot
 
   # We set `perf_event_paranoid=0` so that we can run the cpi-count program and
   # tests without elevated privileges.

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -72,19 +72,20 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: main
       - name: Install `just`
         uses: extractions/setup-just@v2
       - name: Install `go`
         uses: actions/setup-go@v5
         with:
           go-version: "1.22.9"
-      - name: Setup Go environment
-        run: |
-          echo "GOMODCACHE=$HOME/go/pkg/mod" >> $GITHUB_ENV
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          ref: main
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
       - name: Print go version
         run: go version
       - name: Run cpi-count binary

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -47,6 +47,24 @@ jobs:
               {"Key": "Actor", "Value": "${{ github.actor }}"}
             ]
 
+  ensure-perf-event-paranoid:
+    name: Ensure `perf_event_paranoid` is set
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    steps:
+      - name: Check current value
+        run: cat /proc/sys/kernel/perf_event_paranoid
+      - name: Ensure value is 0
+        run: echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid 1>/dev/null
+      - name: Check updated value
+        run: cat /proc/sys/kernel/perf_event_paranoid
+
+  print-available-events:
+    name: Print available events that can be used with `perf -e`
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    steps:
+      - name: Print available events
+        run: perf list
+
   run-tests:
     name: Run tests
     needs: start-runner

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -78,16 +78,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          sparse-checkout: "cmd/cpi-count"
+          sparse-checkout-cone-mode: false
+      - name: Move cpi-count files to root
+        run: |
+          mv cmd/cpi-count/* .
+          rm -rf cmd
+          ls -al
+
       - name: Install `just`
         uses: extractions/setup-just@v2
       - name: Install `go`
         uses: actions/setup-go@v5
         with:
           go-version: "1.22.9"
-          cache: true
-          cache-dependency-path: |
-            **/go.sum
-            **/go.mod
       - name: Print go version
         run: go version
       - name: Run cpi-count binary

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -28,7 +28,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
           ec2-image-id: ami-0884d2865dbe9de4b # Ubuntu 22.04 LTS in us-east-2
-          ec2-instance-type: c5.9xlarge
+          ec2-instance-type: m5zn.6xlarge
           subnet-id: ${{ secrets.AWS_SUBNET_ID }}
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           pre-runner-script: |

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -74,6 +74,8 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Print environment variables
+        run: echo $HOME
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: tverghis/ec2-github-runner@7170053
+        uses: tverghis/ec2-github-runner@7170053c36b2928213de1cf2303ac85059dadeee
         with:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -56,10 +56,16 @@ jobs:
     steps:
       - name: Install `just`
         uses: extractions/setup-just@v2
+      - name: Install `go`
+        uses: actions/setup-go@v5
+        with:
+          go-version: "^1.22.9"
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           ref: main
+      - name: Print go version
+        run: go version
       - name: Run cpi-count binary
         run: just cpi-bin
       - name: Run tests

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -74,8 +74,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Print environment variables
-        run: echo $HOME
+      - name: Set environment variables
+        run: |
+          echo "HOME=/home/runner" >> $GITHUB_ENV
+          echo $HOME
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -61,7 +61,7 @@ jobs:
 
   print-available-events:
     name: Print available events that can be used with `perf -e`
-    needs: ensure-perf-event-paranoid
+    needs: [start-runner, ensure-perf-event-paranoid]
     runs-on: ${{ needs.start-runner.outputs.label }}
     steps:
       - name: Print available events
@@ -69,7 +69,7 @@ jobs:
 
   run-tests:
     name: Run tests
-    needs: ensure-perf-event-paranoid
+    needs: [start-runner, ensure-perf-event-paranoid, print-available-events]
     runs-on: ${{ needs.start-runner.outputs.label }}
     permissions:
       contents: read
@@ -86,8 +86,6 @@ jobs:
           rm -rf cmd
           ls -al
 
-      - name: Install `just`
-        uses: extractions/setup-just@v2
       - name: Install `go`
         uses: actions/setup-go@v5
         with:
@@ -95,13 +93,13 @@ jobs:
       - name: Print go version
         run: go version
       - name: Run cpi-count binary
-        run: just cpi-bin
+        run: go build . && ./cpi-count
       - name: Run tests
-        run: just cpi-test
+        run: go test -count=1 ./...
 
   stop-runner:
     name: Stop EC2 runner
-    needs: [start-runner, run-tests]
+    needs: [start-runner, ensure-perf-event-paranoid, run-tests]
     runs-on: ubuntu-latest
     if: always() # Run even if previous jobs fail
     steps:

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -49,6 +49,7 @@ jobs:
 
   ensure-perf-event-paranoid:
     name: Ensure `perf_event_paranoid` is set
+    needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
     steps:
       - name: Check current value
@@ -60,6 +61,7 @@ jobs:
 
   print-available-events:
     name: Print available events that can be used with `perf -e`
+    needs: ensure-perf-event-paranoid
     runs-on: ${{ needs.start-runner.outputs.label }}
     steps:
       - name: Print available events
@@ -67,7 +69,7 @@ jobs:
 
   run-tests:
     name: Run tests
-    needs: start-runner
+    needs: ensure-perf-event-paranoid
     runs-on: ${{ needs.start-runner.outputs.label }}
     permissions:
       contents: read

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -59,7 +59,10 @@ jobs:
       - name: Install `go`
         uses: actions/setup-go@v5
         with:
-          go-version: "^1.22.9"
+          go-version: "1.22.9"
+      - name: Setup Go environment
+        run: |
+          echo "GOMODCACHE=$HOME/go/pkg/mod" >> $GITHUB_ENV
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -33,7 +33,7 @@ jobs:
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           pre-runner-script: |
             sudo apt update -y && \
-            sudo apt install docker git libicu just -y
+            sudo apt install docker git libicu -y
             sudo systemctl enable docker
           aws-resource-tags: >
             [
@@ -54,6 +54,8 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Install `just`
+        uses: extractions/setup-just@v2
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -74,9 +74,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Set environment variables
+      - name: Create home directory
         run: |
+          mkdir -p /home/runner
           echo "HOME=/home/runner" >> $GITHUB_ENV
+      - name: Print environment variables
+        run: |
           echo $HOME
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -33,7 +33,7 @@ jobs:
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           pre-runner-script: |
             sudo yum update -y && \
-            sudo yum install docker git libicu -y
+            sudo yum install docker git libicu just -y
             sudo systemctl enable docker
           aws-resource-tags: >
             [
@@ -48,13 +48,12 @@ jobs:
             ]
 
   run-tests:
+    name: Run tests
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
     permissions:
       contents: read
     steps:
-      - name: Install `just` # Can we install this with `yum` instead?
-        uses: extractions/setup-just@v2
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -77,6 +77,7 @@ jobs:
       - name: Create home directory
         run: |
           mkdir -p /home/runner
+          chmod -R 777 /home/runner
           echo "HOME=/home/runner" >> $GITHUB_ENV
       - name: Print environment variables
         run: |

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: tverghis/ec2-github-runner@7170053
         with:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
@@ -51,6 +51,7 @@ jobs:
               {"Key": "Branch", "Value": "${{ github.ref_name }}"},
               {"Key": "Actor", "Value": "${{ github.actor }}"}
             ]
+          market-type: spot
 
   # We set `perf_event_paranoid=0` so that we can run the cpi-count program and
   # tests without elevated privileges.

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -28,7 +28,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
           ec2-image-id: ami-0884d2865dbe9de4b # Ubuntu 22.04 LTS in us-east-2
-          ec2-instance-type: t3.micro
+          ec2-instance-type: c5.9xlarge
           subnet-id: ${{ secrets.AWS_SUBNET_ID }}
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           pre-runner-script: |

--- a/justfile
+++ b/justfile
@@ -2,8 +2,8 @@ gobin := `which go`
 
 [working-directory: 'cmd/cpi-count']
 cpi-bin:
-    {{gobin}} build . && sudo -E ./cpi-count
+    {{gobin}} build . && ./cpi-count
 
 [working-directory: 'cmd/cpi-count']
 cpi-test:
-    sudo -E {{gobin}} test -count=1 ./...
+    {{gobin}} test -count=1 ./...

--- a/justfile
+++ b/justfile
@@ -2,8 +2,8 @@ gobin := `which go`
 
 [working-directory: 'cmd/cpi-count']
 cpi-bin:
-    {{gobin}} build . && sudo ./cpi-count
+    {{gobin}} build . && sudo -E ./cpi-count
 
 [working-directory: 'cmd/cpi-count']
 cpi-test:
-    sudo {{gobin}} test -count=1 ./...
+    sudo -E {{gobin}} test -count=1 ./...

--- a/justfile
+++ b/justfile
@@ -1,9 +1,0 @@
-gobin := `which go`
-
-[working-directory: 'cmd/cpi-count']
-cpi-bin:
-    {{gobin}} build . && ./cpi-count
-
-[working-directory: 'cmd/cpi-count']
-cpi-test:
-    {{gobin}} test -count=1 ./...


### PR DESCRIPTION
This patch adds a new workflow, `cpi-count-test.yaml`. This workflow is based on the one created in #38.

The `cpi-count-test.yaml` workflow spins up a self-hosted Github runner on an `c5.9xlarge` EC2 instance, checks out this repository, and executes the `cpi-count` binary and tests. The runner is torn down once the workflow is complete.

Setting `perf_event_paranoid=0` worked fine, and so the program and tests can be run without `sudo` (which would have otherwise complicated things).

The workflow only has a `workflow_dispatch` trigger (i.e., can only be run manually).

Here is an example of a successful run: https://github.com/tverghis/memory-collector/actions/runs/12880226002

Closes #31.

### Notes on cost

Edit: This section is now obsolete because AWS was able to increase the quota to 128 vCPUs, thereby allowing us to provision `c5.9xlarge` instances with no problem. I'll leave the text intact below, for posterity.

I think eventually we'd want to get on the cheaper `c5.9xlarge` instance type, but the default account quotas prevent this out-of-the-box. The instance type has 36 vCPUs, while the quota is set at 32 vCPUs.

[On average in my fork](https://github.com/tverghis/memory-collector/actions/metrics/performance), the workflows take ~2.5mins. As of opening this PR, the costs associated with each instance type in `us-east-2` are:

| Instance type | Hourly rate | Cost per run |
| --- | --- | --- |
| m5zn.6xlarge | $1.982/hr | $0.0825 | 
| c5.9xlarge | $1.53 | $0.0638 |
