### PR TITLE
Use a patched version of the `ec2-github-runner` action to provision runners on Spot instances

### DIFF
--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: tverghis/ec2-github-runner@7170053c36b2928213de1cf2303ac85059dadeee
         with:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
@@ -49,6 +49,7 @@ jobs:
               {"Key": "Branch", "Value": "${{ github.ref_name }}"},
               {"Key": "Actor", "Value": "${{ github.actor }}"}
             ]
+          market-type: spot
 
   # We set `perf_event_paranoid=0` so that we can run the cpi-count program and
   # tests without elevated privileges.

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -31,7 +31,7 @@ jobs:
           # See this Intel VTune documentation that lists the instances that support
           # hardware events:
           # https://www.intel.com/content/www/us/en/developer/articles/technical/intel-vtune-amplifier-functionality-on-aws-instances.html
-          ec2-instance-type: t3.large
+          ec2-instance-type: c5.9xlarge
           subnet-id: ${{ secrets.AWS_SUBNET_ID }}
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           pre-runner-script: |

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -31,7 +31,7 @@ jobs:
           # See this Intel VTune documentation that lists the instances that support
           # hardware events:
           # https://www.intel.com/content/www/us/en/developer/articles/technical/intel-vtune-amplifier-functionality-on-aws-instances.html
-          ec2-instance-type: c5.9xlarge
+          ec2-instance-type: t3.large
           subnet-id: ${{ secrets.AWS_SUBNET_ID }}
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           pre-runner-script: |


### PR DESCRIPTION
The [upstream] `ec2-github-runner` action does not yet support provisioning Spot instances for runners. There is an open PR, but it seems to have stagnated. I've opened a [new PR](https://github.com/machulav/ec2-github-runner/pull/210) with the same changes, but until that gets merged, we can use the same patch from [my own fork](https://github.com/tverghis/ec2-github-runner/tree/spot-instance).

[upstream]: https://github.com/machulav/ec2-github-runner