### PR TITLE
Reduce permissions and fix version in AWS Actions

### DIFF
--- a/.github/workflows/aws-runner-template.yaml
+++ b/.github/workflows/aws-runner-template.yaml
@@ -4,8 +4,6 @@ on: workflow_dispatch  # Manual trigger for testing
 # Add permissions needed for OIDC authentication
 permissions:
   id-token: write # Required for requesting the JWT
-#   contents: read  # Required for actions/checkout
-#   actions: write     # Required for registering runners
 
 jobs:
   start-runner:

--- a/.github/workflows/aws-runner-template.yaml
+++ b/.github/workflows/aws-runner-template.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856
+        uses: machulav/ec2-github-runner@v2.3.8
         with:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
           role-session-name: github-runner-session
 
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856
+        uses: machulav/ec2-github-runner@v2.3.8
         with:
           mode: stop
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}

--- a/.github/workflows/aws-runner-template.yaml
+++ b/.github/workflows/aws-runner-template.yaml
@@ -2,8 +2,8 @@ name: Template for EC2 Runner
 on: workflow_dispatch  # Manual trigger for testing
 
 # Add permissions needed for OIDC authentication
-# permissions:
-#   id-token: write # Required for requesting the JWT
+permissions:
+  id-token: write # Required for requesting the JWT
 #   contents: read  # Required for actions/checkout
 #   actions: write     # Required for registering runners
 

--- a/.github/workflows/aws-runner-template.yaml
+++ b/.github/workflows/aws-runner-template.yaml
@@ -2,10 +2,10 @@ name: Template for EC2 Runner
 on: workflow_dispatch  # Manual trigger for testing
 
 # Add permissions needed for OIDC authentication
-permissions:
-  id-token: write # Required for requesting the JWT
-  contents: read  # Required for actions/checkout
-  actions: write     # Required for registering runners
+# permissions:
+#   id-token: write # Required for requesting the JWT
+#   contents: read  # Required for actions/checkout
+#   actions: write     # Required for registering runners
 
 jobs:
   start-runner:

--- a/.github/workflows/aws-runner-template.yaml
+++ b/.github/workflows/aws-runner-template.yaml
@@ -24,12 +24,13 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856
         with:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
           ec2-image-id: ami-006ec002b74f6c066  # Amazon Linux 2 in us-east-2
           ec2-instance-type: t3.micro
+          market-type: spot
           subnet-id: ${{ secrets.AWS_SUBNET_ID }}
           security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           pre-runner-script: |
@@ -72,7 +73,7 @@ jobs:
           role-session-name: github-runner-session
 
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856
         with:
           mode: stop
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: tverghis/ec2-github-runner@7170053c36b2928213de1cf2303ac85059dadeee
+        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856
         with:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
           role-session-name: github-runner-session
 
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856
         with:
           mode: stop
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856
+        uses: machulav/ec2-github-runner@v2.3.8
         with:
           mode: start
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
           role-session-name: github-runner-session
 
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856
+        uses: machulav/ec2-github-runner@v2.3.8
         with:
           mode: stop
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -3,8 +3,8 @@ on: workflow_dispatch
 
 permissions:
   id-token: write
-  contents: read
-  actions: write
+  # contents: read
+  # actions: write
 
 jobs:
   start-runner:

--- a/.github/workflows/cpi-count-test.yaml
+++ b/.github/workflows/cpi-count-test.yaml
@@ -3,8 +3,6 @@ on: workflow_dispatch
 
 permissions:
   id-token: write
-  # contents: read
-  # actions: write
 
 jobs:
   start-runner:


### PR DESCRIPTION
- Experimented with removing some of the `permissions` and was able to remove two in the AWS template and in the CPI AWS tests.

- Fixed the version of ec2-github-runner to the new version supporting spot

Verified both workflows work, and use spot instances (on the AWS console)