### PR TITLE
Enhance sync_timer benchmark with per-timeslot statistics and visualizations

### DIFF
--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -63,7 +63,7 @@ jobs:
   test-module:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
-    timeout-minutes: ${{ inputs.run-benchmarks == true && 5 || 2 }}  # Add timeout in case system hangs
+    timeout-minutes: ${{ inputs.run-benchmarks == true && 7 || 2 }}  # Add timeout in case system hangs
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -190,12 +190,25 @@ jobs:
         run: |
           sudo apt-get install -y \
             stress-ng \
-            trace-cmd \
-            r-base \
-            r-cran-ggplot2 \
-            r-cran-dplyr \
-            r-cran-tidyr \
-            r-cran-optparse
+            trace-cmd
+
+      - name: Set up home directory
+        run: |
+          # Create home directory if it doesn't exist
+          sudo mkdir -p /home/runner
+          sudo chmod 777 /home/runner
+          # Set HOME environment variable
+          echo "HOME=/home/runner" >> $GITHUB_ENV
+
+      - name: Set up R
+        if: ${{ inputs.run-benchmarks }}
+        uses: r-lib/actions/setup-r@v2
+        
+      - name: Install R dependencies
+        if: ${{ inputs.run-benchmarks }}
+        run: |
+          install.packages(c("ggplot2", "dplyr", "tidyr", "optparse"))
+        shell: Rscript {0}
 
       - name: Run benchmarks
         if: ${{ inputs.run-benchmarks }}

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -190,12 +190,17 @@ jobs:
         run: |
           sudo apt-get install -y \
             stress-ng \
-            trace-cmd \
-            r-base \
-            r-cran-ggplot2 \
-            r-cran-dplyr \
-            r-cran-tidyr \
-            r-cran-optparse
+            trace-cmd
+
+      - name: Set up R
+        if: ${{ inputs.run-benchmarks }}
+        uses: r-lib/actions/setup-r@v2
+        
+      - name: Install R dependencies
+        if: ${{ inputs.run-benchmarks }}
+        run: |
+          install.packages(c("ggplot2", "dplyr", "tidyr", "optparse"))
+        shell: Rscript {0}
 
       - name: Run benchmarks
         if: ${{ inputs.run-benchmarks }}

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -190,17 +190,12 @@ jobs:
         run: |
           sudo apt-get install -y \
             stress-ng \
-            trace-cmd
-
-      - name: Set up R
-        if: ${{ inputs.run-benchmarks }}
-        uses: r-lib/actions/setup-r@v2
-        
-      - name: Install R dependencies
-        if: ${{ inputs.run-benchmarks }}
-        run: |
-          install.packages(c("ggplot2", "dplyr", "tidyr", "optparse"))
-        shell: Rscript {0}
+            trace-cmd \
+            r-base \
+            r-cran-ggplot2 \
+            r-cran-dplyr \
+            r-cran-tidyr \
+            r-cran-optparse
 
       - name: Run benchmarks
         if: ${{ inputs.run-benchmarks }}

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -63,7 +63,7 @@ jobs:
   test-module:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
-    timeout-minutes: ${{ inputs.run-benchmarks == true && 7 || 2 }}  # Add timeout in case system hangs
+    timeout-minutes: ${{ inputs.run-benchmarks == true && 10 || 2 }}  # Add timeout in case system hangs
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -1,8 +1,4 @@
 name: Test Kernel Module
-
-env:
-  DEFAULT_RUN_BENCHMARKS: true  # Set to true/false to control default behavior on push
-
 on: 
   workflow_dispatch:  # Manual trigger for testing
     inputs:
@@ -67,7 +63,7 @@ jobs:
   test-module:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
-    timeout-minutes: ${{ (inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS)) && 10 || 2 }}  # Add timeout in case system hangs
+    timeout-minutes: ${{ inputs.run-benchmarks == true && 10 || 2 }}  # Add timeout in case system hangs
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -190,7 +186,7 @@ jobs:
           fi
 
       - name: Install benchmark dependencies
-        if: ${{ inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS) }}
+        if: ${{ inputs.run-benchmarks }}
         run: |
           sudo apt-get install -y \
             stress-ng \
@@ -215,7 +211,7 @@ jobs:
       #   shell: Rscript {0}
 
       - name: Run benchmarks
-        if: ${{ inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS) }}
+        if: ${{ inputs.run-benchmarks }}
         working-directory: module
         run: |
           ./benchmark_sync_timer_stress.sh > benchmark_results.csv
@@ -223,7 +219,7 @@ jobs:
           head -n 35 benchmark_results.csv
 
       - name: Upload benchmark results
-        if: ${{ inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS) }}
+        if: ${{ inputs.run-benchmarks }}
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
@@ -337,7 +333,7 @@ jobs:
     needs: [test-module]
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS) }}
+    if: ${{ inputs.run-benchmarks }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -200,30 +200,39 @@ jobs:
           # Set HOME environment variable
           echo "HOME=/home/runner" >> $GITHUB_ENV
 
-      - name: Set up R
-        if: ${{ inputs.run-benchmarks }}
-        uses: r-lib/actions/setup-r@v2
+      # - name: Set up R
+      #   if: ${{ inputs.run-benchmarks }}
+      #   uses: r-lib/actions/setup-r@v2
         
-      - name: Install R dependencies
-        if: ${{ inputs.run-benchmarks }}
-        run: |
-          install.packages(c("ggplot2", "dplyr", "tidyr", "optparse"))
-        shell: Rscript {0}
+      # - name: Install R dependencies
+      #   if: ${{ inputs.run-benchmarks }}
+      #   run: |
+      #     install.packages(c("ggplot2", "dplyr", "tidyr", "optparse"))
+      #   shell: Rscript {0}
 
       - name: Run benchmarks
         if: ${{ inputs.run-benchmarks }}
         working-directory: module
         run: |
           ./benchmark_sync_timer_stress.sh > benchmark_results.csv
-          echo "Benchmark results:"
-          cat benchmark_results.csv
+          echo "Benchmark results (head -n 35):"
+          head -n 35 benchmark_results.csv
+
+      - name: Visualize benchmark results
+        if: ${{ inputs.run-benchmarks }}
+        uses: docker://rocker/tidyverse:latest
+        with:
+          entrypoint: sh
+          args: -c "cd /github/workspace/module && Rscript ./visualize_benchmark.R -I 'benchmark_results.csv' -o 'benchmark_results.pdf'"
 
       - name: Upload benchmark results
         if: ${{ inputs.run-benchmarks }}
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: module/benchmark_results.csv
+          path: |
+            module/benchmark_results.csv
+            module/benchmark_results.pdf
 
       - name: Check dmesg on RMID test failure
         if: steps.rmid-allocator-test.outcome == 'failure'

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -192,13 +192,13 @@ jobs:
             stress-ng \
             trace-cmd
 
-      - name: Set up home directory
-        run: |
-          # Create home directory if it doesn't exist
-          sudo mkdir -p /home/runner
-          sudo chmod 777 /home/runner
-          # Set HOME environment variable
-          echo "HOME=/home/runner" >> $GITHUB_ENV
+      # - name: Set up home directory
+      #   run: |
+      #     # Create home directory if it doesn't exist
+      #     sudo mkdir -p /home/runner
+      #     sudo chmod 777 /home/runner
+      #     # Set HOME environment variable
+      #     echo "HOME=/home/runner" >> $GITHUB_ENV
 
       # - name: Set up R
       #   if: ${{ inputs.run-benchmarks }}
@@ -218,21 +218,12 @@ jobs:
           echo "Benchmark results (head -n 35):"
           head -n 35 benchmark_results.csv
 
-      - name: Visualize benchmark results
-        if: ${{ inputs.run-benchmarks }}
-        uses: docker://rocker/tidyverse:latest
-        with:
-          entrypoint: sh
-          args: -c "cd /github/workspace/module && Rscript ./visualize_benchmark.R -I 'benchmark_results.csv' -o 'benchmark_results.pdf'"
-
       - name: Upload benchmark results
         if: ${{ inputs.run-benchmarks }}
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: |
-            module/benchmark_results.csv
-            module/benchmark_results.pdf
+          path: module/benchmark_results.csv
 
       - name: Check dmesg on RMID test failure
         if: steps.rmid-allocator-test.outcome == 'failure'
@@ -337,7 +328,30 @@ jobs:
             echo "*** Run $i:"
             ./test_module.sh
           done
-
+  
+  plot-benchmark:
+    needs: [test-module]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ inputs.run-benchmarks }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Download benchmark results
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-results
+          path: module/benchmark_results.csv
+      - name: Visualize benchmark results
+        uses: docker://rocker/tidyverse:latest
+        with:
+          entrypoint: sh
+          args: -c "cd /github/workspace/module && Rscript ./visualize_benchmark.R -I 'benchmark_results.csv' -o 'benchmark_results.pdf'"
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-pdf
+          path: module/benchmark_results.pdf
 
   stop-runner:
     name: Stop EC2 runner

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -185,10 +185,17 @@ jobs:
             exit 1
           fi
 
-      - name: Install stress tools
+      - name: Install benchmark dependencies
         if: ${{ inputs.run-benchmarks }}
         run: |
-          sudo apt-get install -y stress-ng jq
+          sudo apt-get install -y \
+            stress-ng \
+            trace-cmd \
+            r-base \
+            r-cran-ggplot2 \
+            r-cran-dplyr \
+            r-cran-tidyr \
+            r-cran-optparse
 
       - name: Run benchmarks
         if: ${{ inputs.run-benchmarks }}

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -346,7 +346,7 @@ jobs:
         uses: docker://rocker/tidyverse:latest
         with:
           entrypoint: sh
-          args: -c "cd /github/workspace/module && Rscript ./visualize_benchmark.R -I 'benchmark_results.csv' -o 'benchmark_results.pdf'"
+          args: -c "cd /github/workspace/module && Rscript ./visualize_benchmark.R -i 'benchmark_results.csv' -o 'benchmark_results.pdf'"
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -1,4 +1,8 @@
 name: Test Kernel Module
+
+env:
+  DEFAULT_RUN_BENCHMARKS: true  # Set to true/false to control default behavior on push
+
 on: 
   workflow_dispatch:  # Manual trigger for testing
     inputs:
@@ -63,7 +67,7 @@ jobs:
   test-module:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
-    timeout-minutes: ${{ inputs.run-benchmarks == true && 10 || 2 }}  # Add timeout in case system hangs
+    timeout-minutes: ${{ (inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS)) && 10 || 2 }}  # Add timeout in case system hangs
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -186,7 +190,7 @@ jobs:
           fi
 
       - name: Install benchmark dependencies
-        if: ${{ inputs.run-benchmarks }}
+        if: ${{ inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS) }}
         run: |
           sudo apt-get install -y \
             stress-ng \
@@ -211,7 +215,7 @@ jobs:
       #   shell: Rscript {0}
 
       - name: Run benchmarks
-        if: ${{ inputs.run-benchmarks }}
+        if: ${{ inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS) }}
         working-directory: module
         run: |
           ./benchmark_sync_timer_stress.sh > benchmark_results.csv
@@ -219,7 +223,7 @@ jobs:
           head -n 35 benchmark_results.csv
 
       - name: Upload benchmark results
-        if: ${{ inputs.run-benchmarks }}
+        if: ${{ inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS) }}
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
@@ -333,7 +337,7 @@ jobs:
     needs: [test-module]
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ inputs.run-benchmarks }}
+    if: ${{ inputs.run-benchmarks != null && inputs.run-benchmarks || (github.event_name == 'push' && env.DEFAULT_RUN_BENCHMARKS) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -341,12 +341,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: benchmark-results
-          path: module/benchmark_results.csv
+          path: module/results
       - name: Visualize benchmark results
         uses: docker://rocker/tidyverse:latest
         with:
           entrypoint: sh
-          args: -c "cd /github/workspace/module && Rscript ./visualize_benchmark.R -i 'benchmark_results.csv' -o 'benchmark_results.pdf'"
+          args: -c "cd /github/workspace/module && Rscript ./visualize_benchmark.R -i 'results/benchmark_results.csv' -o 'benchmark_results.pdf'"
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-kernel-module.yaml
+++ b/.github/workflows/test-kernel-module.yaml
@@ -5,12 +5,12 @@ on:
       instance-type:
         description: 'EC2 instance type to use'
         required: false
-        default: 'm7i.metal-24xl'
+        default: 'm7i.xlarge'
         type: string
       run-benchmarks:
         description: 'Run sync timer benchmarks'
-        required: false
-        default: false
+        required: true
+        default: true
         type: boolean
   push:
     branches:

--- a/module/benchmark_sync_timer.sh
+++ b/module/benchmark_sync_timer.sh
@@ -75,8 +75,6 @@ sleep "$DURATION"
 # Stop benchmark and tracing
 log "Stopping trace..."
 sudo trace-cmd stop
-log "Unloading module..."
-sudo rmmod sync_timer_benchmark_module
 
 # Kill stress if it was started
 if [ -n "$STRESS_PID" ]; then
@@ -88,6 +86,9 @@ fi
 # Extract trace data
 log "Extracting trace data..."
 sudo trace-cmd extract -o "$TRACE_FILE"
+
+log "Unloading module..."
+sudo rmmod sync_timer_benchmark_module
 
 # Process trace data
 log "Processing trace data..."

--- a/module/benchmark_sync_timer.sh
+++ b/module/benchmark_sync_timer.sh
@@ -1,76 +1,99 @@
 #!/bin/bash
-
-# Constants
-MODULE_NAME="sync_timer_benchmark_module"
-DMESG_PREFIX="sync_timer_bench:"
-RUNTIME=10  # Runtime in seconds
-
-# Function to extract numeric value from a line
-extract_value() {
-    sed 's/.*: \([0-9]\+\).*/\1/'
-}
+set -e
 
 # Function to log to stderr
 log() {
     echo "$@" >&2
 }
 
-# Clear dmesg
-sudo dmesg -C
-
-# Load the module
-log "Loading benchmark module..."
-sudo insmod "build/${MODULE_NAME}.ko"
-if [ $? -ne 0 ]; then
-    log "Failed to load module"
+# Function to print usage
+usage() {
+    echo "Usage: $0 [-n <name>] [-s <stress_command>] [-d <duration>] [-o <output_csv>]"
+    echo
+    echo "Run sync timer benchmark with optional stress test"
+    echo
+    echo "Options:"
+    echo "  -n <name>           Name of the experiment (default: benchmark)"
+    echo "  -s <stress_command> Optional stress command to run during benchmark"
+    echo "  -d <duration>       Duration in seconds (default: 10)"
+    echo "  -o <output_csv>     Output CSV file (default: benchmark_results.csv)"
+    echo "  -h                  Show this help message"
     exit 1
-fi
-
-# Wait for specified runtime
-log "Running benchmark for ${RUNTIME} seconds..."
-sleep ${RUNTIME}
-
-# Unload the module
-log "Unloading module..."
-sudo rmmod "${MODULE_NAME}"
-if [ $? -ne 0 ]; then
-    log "Failed to unload module"
-    exit 1
-fi
-
-# Process dmesg output
-log "Processing results..."
-dmesg | grep "${DMESG_PREFIX}" > benchmark_raw.log
-
-# Extract global statistics
-TOTAL_SAMPLES=$(grep "Total samples:" benchmark_raw.log | extract_value)
-MIN_DELTA=$(grep "Global min delta:" benchmark_raw.log | extract_value)
-MAX_DELTA=$(grep "Global max delta:" benchmark_raw.log | extract_value)
-MEAN_DELTA=$(grep "Global mean delta:" benchmark_raw.log | extract_value)
-STDDEV=$(grep "Global stddev:" benchmark_raw.log | extract_value)
-MISSED_TICKS=$(grep "Total missed ticks:" benchmark_raw.log | extract_value)
-
-# Output JSON to stdout
-cat << EOF
-{
-    "samples": ${TOTAL_SAMPLES},
-    "min_delta_ns": ${MIN_DELTA},
-    "max_delta_ns": ${MAX_DELTA},
-    "mean_delta_ns": ${MEAN_DELTA},
-    "stddev_ns": ${STDDEV},
-    "missed_ticks": ${MISSED_TICKS}
 }
-EOF
 
-# Clean up
-rm -f benchmark_raw.log
+# Parse command line arguments
+NAME="benchmark"
+STRESS_CMD=""
+DURATION=10
+OUTPUT_CSV="benchmark_results.csv"
 
-# Print summary
-log
-log "Benchmark Summary:"
-log "Total Samples: ${TOTAL_SAMPLES}"
-log "Min Delta: ${MIN_DELTA} ns"
-log "Max Delta: ${MAX_DELTA} ns"
-log "Mean Delta: ${MEAN_DELTA} ns"
-log "Standard Deviation: ${STDDEV} ns"
-log "Missed Ticks: ${MISSED_TICKS}" 
+while getopts "n:s:d:o:h" opt; do
+    case $opt in
+        n) NAME="$OPTARG" ;;
+        s) STRESS_CMD="$OPTARG" ;;
+        d) DURATION="$OPTARG" ;;
+        o) OUTPUT_CSV="$OPTARG" ;;
+        h) usage ;;
+        \?) usage ;;
+    esac
+done
+
+# Make sure we're in the module directory
+cd "$(dirname "$0")"
+
+# Generate unique trace file name
+TRACE_FILE="/tmp/sync_timer_trace_${NAME}_$$.dat"
+
+log "Running benchmark: $NAME"
+
+# Build the benchmark module if needed
+if [ ! -f "build/sync_timer_benchmark_module.ko" ]; then
+    log "Building benchmark module..."
+    make sync_timer_benchmark
+fi
+
+# Load benchmark module and wait
+log "Loading benchmark module..."
+sudo insmod "build/sync_timer_benchmark_module.ko"
+
+if [ -n "$STRESS_CMD" ]; then
+    log "Starting stress: $STRESS_CMD"
+    eval "$STRESS_CMD" 1>&2 2>&2 &
+    STRESS_PID=$!
+    sleep 2  # Let the stress command ramp up
+else
+    sleep .5  # Let the module ramp up
+fi
+
+# Start tracing
+log "Starting trace..."
+sudo trace-cmd start -e sync_timer_stats
+
+log "Running for $DURATION seconds..."
+sleep "$DURATION"
+
+# Stop benchmark and tracing
+log "Stopping trace..."
+sudo trace-cmd stop
+log "Unloading module..."
+sudo rmmod sync_timer_benchmark_module
+
+# Kill stress if it was started
+if [ -n "$STRESS_PID" ]; then
+    pkill -TERM -P "$STRESS_PID" 2>/dev/null
+    kill -9 "$STRESS_PID" 2>/dev/null
+    wait "$STRESS_PID" 2>/dev/null
+fi
+
+# Extract trace data
+log "Extracting trace data..."
+sudo trace-cmd extract -o "$TRACE_FILE"
+
+# Process trace data
+log "Processing trace data..."
+./process_benchmark.sh "$TRACE_FILE" "$NAME" "$OUTPUT_CSV"
+
+# Clean up trace file
+rm -f "$TRACE_FILE"
+
+log "Benchmark complete. Results appended to $OUTPUT_CSV" 

--- a/module/benchmark_sync_timer.sh
+++ b/module/benchmark_sync_timer.sh
@@ -78,7 +78,7 @@ sudo trace-cmd stop
 
 # Kill stress if it was started
 if [ -n "$STRESS_PID" ]; then
-    pkill -TERM -P "$STRESS_PID" 2>/dev/null
+    pkill -TERM -P "$STRESS_PID" 2>/dev/null || true
     kill -9 "$STRESS_PID" 2>/dev/null || true
     wait "$STRESS_PID" 2>/dev/null || true
 fi

--- a/module/benchmark_sync_timer.sh
+++ b/module/benchmark_sync_timer.sh
@@ -79,8 +79,8 @@ sudo trace-cmd stop
 # Kill stress if it was started
 if [ -n "$STRESS_PID" ]; then
     pkill -TERM -P "$STRESS_PID" 2>/dev/null
-    kill -9 "$STRESS_PID" 2>/dev/null
-    wait "$STRESS_PID" 2>/dev/null
+    kill -9 "$STRESS_PID" 2>/dev/null || true
+    wait "$STRESS_PID" 2>/dev/null || true
 fi
 
 # Extract trace data

--- a/module/benchmark_sync_timer_stress.sh
+++ b/module/benchmark_sync_timer_stress.sh
@@ -89,8 +89,4 @@ if stress-ng --help | grep -q -- "--mutex"; then
         -d "$DURATION" -o "$OUTPUT_CSV"
 fi
 
-# Generate visualization
-log "Generating visualization..."
-./visualize_benchmark.R -i "$OUTPUT_CSV" -o "$PLOT_FILE"
-
-log "Benchmark complete. Results in $OUTPUT_CSV and $PLOT_FILE"
+log "Benchmark complete. Results in $OUTPUT_CSV"

--- a/module/benchmark_sync_timer_stress.sh
+++ b/module/benchmark_sync_timer_stress.sh
@@ -1,77 +1,96 @@
 #!/bin/bash
+set -e
 
 # Function to log to stderr
 log() {
     echo "$@" >&2
 }
 
-# Function to run a benchmark with a specific stressor
-run_benchmark() {
-    local name="$1"
-    local stress_cmd="$2"
-    local stress_pid=""
-
-    log "Running benchmark: $name"
-    
-    if [ -n "$stress_cmd" ]; then
-        log "Starting stress: $stress_cmd"
-        $stress_cmd 1>&2 2>&2 &
-        stress_pid=$!
-        sleep 2  # Let the stress command ramp up
-    fi
-
-    # Run benchmark and capture JSON output
-    local json_output
-    json_output=$(./benchmark_sync_timer.sh)
-    local status=$?
-
-    # Kill stress if it was started
-    if [ -n "$stress_pid" ]; then
-        pkill -TERM -P $stress_pid 2>/dev/null
-        kill -9 $stress_pid 2>/dev/null
-        wait $stress_pid 2>/dev/null
-    fi
-
-    if [ $status -ne 0 ]; then
-        log "Benchmark failed for: $name"
-        return 1
-    fi
-
-    # Parse JSON and output CSV line
-    local samples=$(echo "$json_output" | jq -r '.samples')
-    local min_delta=$(echo "$json_output" | jq -r '.min_delta_ns')
-    local max_delta=$(echo "$json_output" | jq -r '.max_delta_ns')
-    local mean_delta=$(echo "$json_output" | jq -r '.mean_delta_ns')
-    local stddev=$(echo "$json_output" | jq -r '.stddev_ns')
-    local missed_ticks=$(echo "$json_output" | jq -r '.missed_ticks')
-
-    echo "$name,$samples,$min_delta,$max_delta,$mean_delta,$stddev,$missed_ticks"
+# Function to print usage
+usage() {
+    echo "Usage: $0 [-d <duration>] [-o <output_csv>] [-p <plot_file>]"
+    echo
+    echo "Run sync timer benchmark under various stress conditions"
+    echo
+    echo "Options:"
+    echo "  -d <duration>   Duration for each test in seconds (default: 10)"
+    echo "  -o <output_csv> Output CSV file (default: benchmark_results.csv)"
+    echo "  -p <plot_file> Output plot file (default: benchmark_plot.pdf)"
+    echo "  -h             Show this help message"
+    exit 1
 }
 
-# Output CSV header
-echo "test,samples,min_delta_ns,max_delta_ns,mean_delta_ns,stddev_ns,missed_ticks"
+# Parse command line arguments
+DURATION=10
+OUTPUT_CSV="benchmark_results.csv"
+PLOT_FILE="benchmark_plot.pdf"
+
+while getopts "d:o:p:h" opt; do
+    case $opt in
+        d) DURATION="$OPTARG" ;;
+        o) OUTPUT_CSV="$OPTARG" ;;
+        p) PLOT_FILE="$OPTARG" ;;
+        h) usage ;;
+        \?) usage ;;
+    esac
+done
+
+# Make sure we're in the module directory
+cd "$(dirname "$0")"
+
+# Create fresh results file
+rm -f "$OUTPUT_CSV"
 
 # Run baseline benchmark
-run_benchmark "baseline" ""
+log "Running baseline test..."
+./benchmark_sync_timer.sh -n "baseline" -d "$DURATION" -o "$OUTPUT_CSV"
 
 # CPU and scheduler stress
-run_benchmark "cpu_stress" "stress-ng --cpu \$(nproc) --cpu-method matrixprod"
+log "Running CPU stress test..."
+./benchmark_sync_timer.sh -n "cpu_stress" \
+    -s "stress-ng --cpu \$(nproc) --cpu-method matrixprod" \
+    -d "$DURATION" -o "$OUTPUT_CSV"
 
 # Memory and cache contention
-run_benchmark "memory_stress" "stress-ng --vm 4 --vm-bytes 75%"
+log "Running memory stress test..."
+./benchmark_sync_timer.sh -n "memory_stress" \
+    -s "stress-ng --vm 4 --vm-bytes 75%" \
+    -d "$DURATION" -o "$OUTPUT_CSV"
 
 # Interrupt generation
-run_benchmark "interrupt_stress" "stress-ng --timer 8 --timer-freq 1000"
+log "Running interrupt stress test..."
+./benchmark_sync_timer.sh -n "interrupt_stress" \
+    -s "stress-ng --timer 8 --timer-freq 1000" \
+    -d "$DURATION" -o "$OUTPUT_CSV"
 
 # I/O and system call pressure
-run_benchmark "io_stress" "stress-ng --hdd 4 --hdd-bytes 1G"
-run_benchmark "syscall_stress" "stress-ng --syscall 4"
+log "Running I/O stress test..."
+./benchmark_sync_timer.sh -n "io_stress" \
+    -s "stress-ng --hdd 4 --hdd-bytes 1G" \
+    -d "$DURATION" -o "$OUTPUT_CSV"
+
+log "Running syscall stress test..."
+./benchmark_sync_timer.sh -n "syscall_stress" \
+    -s "stress-ng --syscall 4" \
+    -d "$DURATION" -o "$OUTPUT_CSV"
 
 # Lock contention
-run_benchmark "lock_stress" "stress-ng --lockbus 4"
+log "Running lock stress test..."
+./benchmark_sync_timer.sh -n "lock_stress" \
+    -s "stress-ng --lockbus 4" \
+    -d "$DURATION" -o "$OUTPUT_CSV"
 
 # Mutex stress
 # only run if `stress-ng --help` shows --mutex
 if stress-ng --help | grep -q -- "--mutex"; then
-    run_benchmark "mutex_stress" "stress-ng --mutex 8" 
+    log "Running mutex stress test..."
+    ./benchmark_sync_timer.sh -n "mutex_stress" \
+        -s "stress-ng --mutex 8" \
+        -d "$DURATION" -o "$OUTPUT_CSV"
 fi
+
+# Generate visualization
+log "Generating visualization..."
+./visualize_benchmark.R -i "$OUTPUT_CSV" -o "$PLOT_FILE"
+
+log "Benchmark complete. Results in $OUTPUT_CSV and $PLOT_FILE"

--- a/module/process_benchmark.sh
+++ b/module/process_benchmark.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+# Function to print usage
+usage() {
+    echo "Usage: $0 <trace_file> <experiment_name> <output_csv>"
+    echo
+    echo "Process sync timer benchmark trace data and generate CSV output"
+    echo
+    echo "Arguments:"
+    echo "  trace_file      - Input trace file from trace-cmd"
+    echo "  experiment_name - Name of experiment (e.g., baseline, cpu_stress)"
+    echo "  output_csv      - Output CSV file path"
+    exit 1
+}
+
+# Check arguments
+if [ "$#" -ne 3 ]; then
+    usage
+fi
+
+TRACE_FILE="$1"
+EXPERIMENT="$2"
+OUTPUT_CSV="$3"
+
+# Create CSV header if file doesn't exist
+if [ ! -f "$OUTPUT_CSV" ]; then
+    echo "timestamp,tick,min_delay,max_delay,mean_delay,stddev,samples,missing,experiment" > "$OUTPUT_CSV"
+fi
+
+# Process trace file and append to CSV
+# Format: ts=<ts> tick=<tick> min=<min> max=<max> mean=<mean> stddev=<stddev> samples=<n> missing=<m>
+trace-cmd report -i "$TRACE_FILE" | grep "sync_timer_stats:" | while read -r line; do
+    # Extract values using awk
+    values=$(echo "$line" | awk '{
+        for(i=1; i<=NF; i++) {
+            split($i, pair, "=")
+            if(pair[1] == "ts") ts = pair[2]
+            if(pair[1] == "tick") tick = pair[2]
+            if(pair[1] == "min") min = pair[2]
+            if(pair[1] == "max") max = pair[2]
+            if(pair[1] == "mean") mean = pair[2]
+            if(pair[1] == "stddev") stddev = pair[2]
+            if(pair[1] == "samples") samples = pair[2]
+            if(pair[1] == "missing") missing = pair[2]
+        }
+        printf "%s,%s,%s,%s,%s,%s,%s,%s", ts, tick, min, max, mean, stddev, samples, missing
+    }')
+    
+    # Append to CSV with experiment name
+    echo "$values,$EXPERIMENT" >> "$OUTPUT_CSV"
+done
+
+echo "Processing complete. Data appended to $OUTPUT_CSV" 

--- a/module/sync_timer_benchmark.h
+++ b/module/sync_timer_benchmark.h
@@ -1,0 +1,52 @@
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM sync_timer_benchmark
+
+#if !defined(_SYNC_TIMER_BENCHMARK_TRACE_H) || defined(TRACE_HEADER_MULTI_READ)
+#define _SYNC_TIMER_BENCHMARK_TRACE_H
+
+#include <linux/tracepoint.h>
+
+TRACE_EVENT(sync_timer_stats,
+    TP_PROTO(u64 timestamp, u64 tick_number, u64 min_delay, u64 max_delay,
+             u64 mean_delay, u64 stddev, u32 sample_count, u32 missing_count),
+    
+    TP_ARGS(timestamp, tick_number, min_delay, max_delay, mean_delay, stddev,
+            sample_count, missing_count),
+    
+    TP_STRUCT__entry(
+        __field(u64, timestamp)
+        __field(u64, tick_number)
+        __field(u64, min_delay)
+        __field(u64, max_delay)
+        __field(u64, mean_delay)
+        __field(u64, stddev)
+        __field(u32, sample_count)
+        __field(u32, missing_count)
+    ),
+    
+    TP_fast_assign(
+        __entry->timestamp = timestamp;
+        __entry->tick_number = tick_number;
+        __entry->min_delay = min_delay;
+        __entry->max_delay = max_delay;
+        __entry->mean_delay = mean_delay;
+        __entry->stddev = stddev;
+        __entry->sample_count = sample_count;
+        __entry->missing_count = missing_count;
+    ),
+    
+    TP_printk("ts=%llu tick=%llu min=%llu max=%llu mean=%llu stddev=%llu samples=%u missing=%u",
+        __entry->timestamp, __entry->tick_number, __entry->min_delay,
+        __entry->max_delay, __entry->mean_delay, __entry->stddev,
+        __entry->sample_count, __entry->missing_count)
+);
+
+#endif /* _SYNC_TIMER_BENCHMARK_TRACE_H */
+
+#undef TRACE_INCLUDE_PATH
+#define TRACE_INCLUDE_PATH .
+#undef TRACE_INCLUDE_FILE
+#define TRACE_INCLUDE_FILE sync_timer_benchmark
+
+/* This part must be outside protection */
+#include <trace/define_trace.h> 

--- a/module/tracepoints.h
+++ b/module/tracepoints.h
@@ -107,6 +107,41 @@ TRACE_EVENT(rmid_existing,
         __entry->rmid, __entry->comm, __entry->tgid, __entry->timestamp)
 );
 
+TRACE_EVENT(sync_timer_stats,
+    TP_PROTO(u64 timestamp, u64 tick_number, u64 min_delay, u64 max_delay,
+             u64 mean_delay, u64 stddev, u32 sample_count, u32 missing_count),
+    
+    TP_ARGS(timestamp, tick_number, min_delay, max_delay, mean_delay, stddev,
+            sample_count, missing_count),
+    
+    TP_STRUCT__entry(
+        __field(u64, timestamp)
+        __field(u64, tick_number)
+        __field(u64, min_delay)
+        __field(u64, max_delay)
+        __field(u64, mean_delay)
+        __field(u64, stddev)
+        __field(u32, sample_count)
+        __field(u32, missing_count)
+    ),
+    
+    TP_fast_assign(
+        __entry->timestamp = timestamp;
+        __entry->tick_number = tick_number;
+        __entry->min_delay = min_delay;
+        __entry->max_delay = max_delay;
+        __entry->mean_delay = mean_delay;
+        __entry->stddev = stddev;
+        __entry->sample_count = sample_count;
+        __entry->missing_count = missing_count;
+    ),
+    
+    TP_printk("ts=%llu tick=%llu min=%llu max=%llu mean=%llu stddev=%llu samples=%u missing=%u",
+        __entry->timestamp, __entry->tick_number, __entry->min_delay,
+        __entry->max_delay, __entry->mean_delay, __entry->stddev,
+        __entry->sample_count, __entry->missing_count)
+);
+
 #endif /* _MEMORY_COLLECTOR_TRACE_H */
 
 #undef TRACE_INCLUDE_PATH

--- a/module/visualize_benchmark.R
+++ b/module/visualize_benchmark.R
@@ -22,7 +22,7 @@ option_list = list(
                 help="Plot height in inches [default= %default]", metavar="number")
 )
 
-opt_parser = OptionParser(option_list=option_list)
+opt_parser = OptionParser(option_list=option_list, add_help_option=FALSE)
 opt = parse_args(opt_parser)
 
 if (is.null(opt$input)) {

--- a/module/visualize_benchmark.R
+++ b/module/visualize_benchmark.R
@@ -1,0 +1,74 @@
+#!/usr/bin/env Rscript
+
+# Check for required packages and install if missing
+required_packages <- c("ggplot2", "dplyr", "tidyr", "optparse")
+new_packages <- required_packages[!(required_packages %in% installed.packages()[,"Package"])]
+if(length(new_packages)) install.packages(new_packages)
+
+library(ggplot2)
+library(dplyr)
+library(tidyr)
+library(optparse)
+
+# Parse command line arguments
+option_list = list(
+    make_option(c("-i", "--input"), type="character", default=NULL, 
+                help="Input CSV file", metavar="character"),
+    make_option(c("-o", "--output"), type="character", default="benchmark_plot.pdf",
+                help="Output plot file [default= %default]", metavar="character"),
+    make_option(c("-w", "--width"), type="numeric", default=12,
+                help="Plot width in inches [default= %default]", metavar="number"),
+    make_option(c("-h", "--height"), type="numeric", default=8,
+                help="Plot height in inches [default= %default]", metavar="number")
+)
+
+opt_parser = OptionParser(option_list=option_list)
+opt = parse_args(opt_parser)
+
+if (is.null(opt$input)) {
+    print_help(opt_parser)
+    stop("Input CSV file must be specified.", call.=FALSE)
+}
+
+# Read data
+data <- read.csv(opt$input)
+
+# Convert timestamp to relative seconds from start
+data <- data %>%
+    group_by(experiment) %>%
+    mutate(
+        relative_time = (timestamp - min(timestamp)) / 1e9,  # Convert ns to s
+        mean_delay_us = mean_delay / 1000,  # Convert ns to μs
+        min_delay_us = min_delay / 1000,
+        max_delay_us = max_delay / 1000,
+        stddev_us = stddev / 1000
+    )
+
+# Create plot
+p <- ggplot(data, aes(x=relative_time)) +
+    # Plot min-max range
+    geom_ribbon(aes(ymin=min_delay_us, ymax=max_delay_us, fill=experiment), alpha=0.2) +
+    # Plot mean with points
+    geom_point(aes(y=mean_delay_us, color=experiment), size=1, alpha=0.5) +
+    # Add error bars for standard deviation
+    geom_errorbar(aes(ymin=mean_delay_us-stddev_us, ymax=mean_delay_us+stddev_us, color=experiment),
+                 width=0.1, alpha=0.3) +
+    # Facet by experiment
+    facet_wrap(~experiment, ncol=1, scales="free_y") +
+    # Labels and theme
+    labs(x="Time (seconds)",
+         y="Timer Delay (μs)",
+         title="Sync Timer Benchmark Results",
+         subtitle="Points show mean delay, bands show min-max range, error bars show ±1σ") +
+    theme_minimal() +
+    theme(
+        legend.position="none",
+        panel.grid.minor=element_blank(),
+        strip.text=element_text(size=12, face="bold"),
+        plot.title=element_text(size=14, face="bold"),
+        plot.subtitle=element_text(size=10)
+    )
+
+# Save plot
+ggsave(opt$output, p, width=opt$width, height=opt$height)
+cat(sprintf("Plot saved to %s\n", opt$output)) 


### PR DESCRIPTION
- Extracts per-timeslot timing statistics using tracepoints.
- Writes a CSV with one of the fields being which test ran
- Plots time progression of timing statistics for all the tests on one pdf
- Github action can run the benchmark and upload artifacts with the results and plots

closes #94