### PR TITLE
Improve showing volatility in LLC miss plots

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -587,7 +587,9 @@ jobs:
       - name: Generate LLC Misses Plots
         run: |
           # Generate LLC misses plots
-          Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 180 1 visualization_results/llc_misses
+          Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 180 0.3 visualization_results/llc_misses_0.3sec
+          Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 180 0.5 visualization_results/llc_misses_0.5sec
+          Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 180 1 visualization_results/llc_misses_1sec
           Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 182 3 visualization_results/llc_misses_3sec
           Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 190 10 visualization_results/llc_misses_10sec
           

--- a/scripts/plot_llc_misses.R
+++ b/scripts/plot_llc_misses.R
@@ -25,7 +25,7 @@ input_file <- if(length(args) >= 1) args[1] else "collector-parquet.parquet"
 start_time_offset <- if(length(args) >= 2) as.numeric(args[2]) else 110  # Default to 110 seconds after start
 window_size <- if(length(args) >= 3) as.numeric(args[3]) else 1  # Default to 1 second window
 output_file <- if(length(args) >= 4) args[4] else "llc_misses"
-top_n_processes <- if(length(args) >= 5) as.numeric(args[5]) else 100  # Default to showing top processes
+top_n_processes <- if(length(args) >= 5) as.numeric(args[5]) else 15  # Default to showing top processes
 
 # Cache line size in bytes
 CACHE_LINE_SIZE <- 64
@@ -186,7 +186,7 @@ create_llc_misses_plot <- function(data, n_top_processes = top_n_processes) {
   
   # Create the stacked area plot
   p <- ggplot(ms_data, aes(x = ms_bucket, y = gb_per_second, fill = process_group)) +
-    geom_area(position = "stack", alpha = 0.8) +
+    geom_col(position = "stack", width = 1.0, alpha = 0.8) +
     scale_fill_manual(values = all_colors) +
     scale_y_continuous(labels = function(x) sprintf("%.2f GB/s", x)) +
     labs(


### PR DESCRIPTION
The previous plots used `geom_area` which smoothed out the measurements. Switched to `geom_col`.

Added 0.3 second and 0.5 second plots to better show detail on smaller screens