### PR TITLE
Scale OpenTelemetry demo benchmark to achieve higher CPU utilization

### DIFF
--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -83,6 +83,9 @@ outputs:
   ec2-instance-id:
     description: 'The ID of the created EC2 instance'
     value: ${{ steps.runner-outputs.outputs.ec2-instance-id }}
+  region:
+    description: 'AWS region where the EC2 instance was created'
+    value: ${{ steps.runner-outputs.outputs.region }}
 
 runs:
   using: 'composite'
@@ -182,7 +185,7 @@ runs:
     # Start EC2 runner with availability-zones-config
     - name: Start EC2 runner
       id: start-ec2-runner
-      uses: yonch/ec2-github-runner@385b5c7e55918be079252eff6e647215fc8f28d6
+      uses: yonch/ec2-github-runner@7a4aa1ca6bf1a5c20e2695db772465e3fced63a2
       with:
         mode: start
         startup-quiet-period-seconds: 10
@@ -214,7 +217,8 @@ runs:
         if [ -n "${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" ]; then
           echo "label=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
           echo "ec2-instance-id=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "Runner successfully started"
+          echo "region=${{ steps.start-ec2-runner.outputs.region }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started in region: ${{ steps.start-ec2-runner.outputs.region }}"
         else
           echo "All runner attempts failed. Please check AWS capacity availability across regions."
           exit 1

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -155,7 +155,12 @@ runs:
         
         # Read the full AZ configs
         AZ_CONFIGS=$(cat /tmp/az_configs.json)
-        echo "availability_zones_config=$AZ_CONFIGS" >> $GITHUB_OUTPUT
+        
+        # Properly escape the multiline JSON for GitHub Actions output
+        # See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        echo "availability_zones_config<<EOF" >> $GITHUB_OUTPUT
+        echo "$AZ_CONFIGS" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
         
         # Get the first region for the initial AWS credentials
         FIRST_REGION=$(jq -r '.[0].region' /tmp/az_configs.json)

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -83,15 +83,12 @@ outputs:
   ec2-instance-id:
     description: 'The ID of the created EC2 instance'
     value: ${{ steps.runner-outputs.outputs.ec2-instance-id }}
-  region:
-    description: 'The AWS region where the instance was created'
-    value: ${{ steps.runner-outputs.outputs.region }}
 
 runs:
   using: 'composite'
   steps:
-    - name: Parse Region Configurations
-      id: parse-regions
+    - name: Generate Region Configurations
+      id: generate-configs
       shell: bash
       run: |
         # Parse the region configs
@@ -103,88 +100,95 @@ runs:
         echo '${{ inputs.region-configs }}' > /tmp/region_configs.json
         echo '${{ inputs.ami-mappings }}' > /tmp/ami_mappings.json
         
-        # Use jq to extract information
+        # Get all regions
         REGIONS=$(jq -r 'keys | join(",")' /tmp/region_configs.json)
-        echo "REGIONS=${REGIONS}" >> $GITHUB_OUTPUT
+        echo "Available regions: $REGIONS"
         
-        # Count the total number of region+subnet combinations
-        COMBO_COUNT=0
+        # Create an array to hold all AZ configurations
+        echo "Generating availability zone configurations for all regions..."
+        echo "[" > /tmp/az_configs.json
         
-        # Loop through each region using jq
+        FIRST=true
+        
+        # Loop through each region
         for region in $(jq -r 'keys[]' /tmp/region_configs.json); do
-          echo "Processing region: ${region}"
+          echo "Processing region: $region"
+          
+          # Get AMI ID for this region
+          AMI_ID=$(jq -r --arg r "$region" --arg it "${{ inputs.image-type }}" '.[$it][$r]' /tmp/ami_mappings.json)
+          if [ -z "$AMI_ID" ] || [ "$AMI_ID" == "null" ]; then
+            echo "Warning: No AMI found for ${{ inputs.image-type }} in region $region, skipping"
+            continue
+          fi
           
           # Get security group for this region
-          SECURITY_GROUP=$(jq -r --arg r "${region}" '.[$r]["security-group-id"]' /tmp/region_configs.json)
-          echo "Security group for ${region}: ${SECURITY_GROUP}"
+          SG_ID=$(jq -r --arg r "$region" '.[$r]["security-group-id"]' /tmp/region_configs.json)
+          if [ -z "$SG_ID" ] || [ "$SG_ID" == "null" ]; then
+            echo "Warning: No security group found for region $region, skipping"
+            continue
+          fi
           
           # Get subnets for this region
-          SUBNETS=$(jq -r --arg r "${region}" '.[$r].subnets[]' /tmp/region_configs.json)
+          SUBNETS=$(jq -r --arg r "$region" '.[$r].subnets[]' /tmp/region_configs.json)
+          if [ -z "$SUBNETS" ]; then
+            echo "Warning: No subnets found for region $region, skipping"
+            continue
+          fi
           
-          # Get AMI ID for this region and image type
-          AMI_ID=$(jq -r --arg r "${region}" --arg it "${{ inputs.image-type }}" '.[$it][$r]' /tmp/ami_mappings.json)
-          echo "AMI ID for ${region} with image type ${{ inputs.image-type }}: ${AMI_ID}"
-          
-          # Process each subnet in this region
+          # Add each subnet as a separate AZ configuration
           for subnet in $SUBNETS; do
-            COMBO_COUNT=$((COMBO_COUNT+1))
-            echo "Found combination ${COMBO_COUNT}: Region=${region}, Subnet=${subnet}, SG=${SECURITY_GROUP}, AMI=${AMI_ID}"
-            
-            if [ $COMBO_COUNT -le 10 ]; then  # Limiting to 10 combinations
-              echo "COMBO_${COMBO_COUNT}_REGION=${region}" >> $GITHUB_OUTPUT
-              echo "COMBO_${COMBO_COUNT}_SUBNET=${subnet}" >> $GITHUB_OUTPUT
-              echo "COMBO_${COMBO_COUNT}_SG=${SECURITY_GROUP}" >> $GITHUB_OUTPUT
-              echo "COMBO_${COMBO_COUNT}_AMI=${AMI_ID}" >> $GITHUB_OUTPUT
+            if [ "$FIRST" = true ]; then
+              FIRST=false
+            else
+              echo "," >> /tmp/az_configs.json
             fi
+            
+            # Add this AZ configuration to the JSON array using printf instead of heredoc
+            printf '  {\n    "region": "%s",\n    "imageId": "%s",\n    "subnetId": "%s",\n    "securityGroupId": "%s"\n  }' "$region" "$AMI_ID" "$subnet" "$SG_ID" >> /tmp/az_configs.json
           done
         done
         
-        echo "Total combinations found: ${COMBO_COUNT}"
-        echo "TOTAL_COMBOS=${COMBO_COUNT}" >> $GITHUB_OUTPUT
-        echo "MAX_COMBOS=$(( COMBO_COUNT > 10 ? 10 : COMBO_COUNT ))" >> $GITHUB_OUTPUT
-
-    - name: Display Region Combinations
-      shell: bash
-      run: |
-        echo "Available region combinations:"
-        MAX_COMBOS="${{ steps.parse-regions.outputs.MAX_COMBOS }}"
+        echo "]" >> /tmp/az_configs.json
         
-        for i in $(seq 1 $MAX_COMBOS); do
-          echo "Combination $i:"
-          echo "  Region: ${{ steps.parse-regions.outputs.COMBO_${i}_REGION }}"
-          echo "  Subnet: ${{ steps.parse-regions.outputs.COMBO_${i}_SUBNET }}"
-          echo "  Security Group: ${{ steps.parse-regions.outputs.COMBO_${i}_SG }}"
-          echo "  AMI: ${{ steps.parse-regions.outputs.COMBO_${i}_AMI }}"
-        done
+        # Create a JSON array for each region's AZ configurations
+        echo "Creating per-region AZ configurations..."
+        
+        # Read the full AZ configs
+        AZ_CONFIGS=$(cat /tmp/az_configs.json)
+        echo "availability_zones_config=$AZ_CONFIGS" >> $GITHUB_OUTPUT
+        
+        # Get the first region for the initial AWS credentials
+        FIRST_REGION=$(jq -r '.[0].region' /tmp/az_configs.json)
+        echo "first_region=$FIRST_REGION" >> $GITHUB_OUTPUT
+        
+        # For debugging, show the AZ configurations
+        echo "Generated availability zone configurations:"
+        cat /tmp/az_configs.json
 
-    # Now we define steps for each combination using proper AWS actions
-    - name: Configure AWS credentials for Attempt 1
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 1 }}
-      id: aws-credentials-1
+    # Configure AWS credentials for the first region
+    - name: Configure AWS credentials
+      id: aws-credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: ${{ steps.parse-regions.outputs.COMBO_1_REGION }}
-        role-session-name: github-runner-session-1
+        aws-region: ${{ steps.generate-configs.outputs.first_region }}
+        role-session-name: github-runner-session
 
-    - name: Start EC2 runner (Attempt 1)
-      id: start-ec2-runner-1
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 1 }}
-      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
-      continue-on-error: true
+    # Start EC2 runner with availability-zones-config
+    - name: Start EC2 runner
+      id: start-ec2-runner
+      uses: yonch/ec2-github-runner@385b5c7e55918be079252eff6e647215fc8f28d6
       with:
         mode: start
         startup-quiet-period-seconds: 10
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_1_AMI }}
         ec2-instance-type: ${{ inputs.instance-type }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-regions.outputs.COMBO_1_SUBNET }}
-        security-group-id: ${{ steps.parse-regions.outputs.COMBO_1_SG }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
         iam-role-name: ${{ inputs.iam-role-name }}
+        availability-zones-config: ${{ steps.generate-configs.outputs.availability_zones_config }}
         aws-resource-tags: >
           [
             {"Key": "Name", "Value": "${{ inputs.runner-name-prefix }}"},
@@ -194,208 +198,19 @@ runs:
             {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
             {"Key": "SHA", "Value": "${{ github.sha }}"},
             {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"},
-            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_1_REGION }}"}
-          ]
-
-    - name: Configure AWS credentials for Attempt 2
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 2 && steps.start-ec2-runner-1.outcome == 'failure' }}
-      id: aws-credentials-2
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: ${{ steps.parse-regions.outputs.COMBO_2_REGION }}
-        role-session-name: github-runner-session-2
-
-    - name: Start EC2 runner (Attempt 2)
-      id: start-ec2-runner-2
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 2 && steps.start-ec2-runner-1.outcome == 'failure' }}
-      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
-      continue-on-error: true
-      with:
-        mode: start
-        startup-quiet-period-seconds: 10
-        startup-retry-interval-seconds: 5
-        github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_2_AMI }}
-        ec2-instance-type: ${{ inputs.instance-type }}
-        market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-regions.outputs.COMBO_2_SUBNET }}
-        security-group-id: ${{ steps.parse-regions.outputs.COMBO_2_SG }}
-        ec2-volume-size: ${{ inputs.volume-size }}
-        pre-runner-script: ${{ inputs.pre-runner-script }}
-        iam-role-name: ${{ inputs.iam-role-name }}
-        aws-resource-tags: >
-          [
-            {"Key": "Name", "Value": "${{ inputs.runner-name-prefix }}"},
-            {"Key": "Repository", "Value": "${{ github.repository }}"},
-            {"Key": "Workflow", "Value": "${{ github.workflow }}"},
-            {"Key": "RunId", "Value": "${{ github.run_id }}"},
-            {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
-            {"Key": "SHA", "Value": "${{ github.sha }}"},
-            {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"},
-            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_2_REGION }}"}
-          ]
-
-    - name: Configure AWS credentials for Attempt 3
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 3 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
-      id: aws-credentials-3
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: ${{ steps.parse-regions.outputs.COMBO_3_REGION }}
-        role-session-name: github-runner-session-3
-
-    - name: Start EC2 runner (Attempt 3)
-      id: start-ec2-runner-3
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 3 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
-      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
-      continue-on-error: true
-      with:
-        mode: start
-        startup-quiet-period-seconds: 10
-        startup-retry-interval-seconds: 5
-        github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_3_AMI }}
-        ec2-instance-type: ${{ inputs.instance-type }}
-        market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-regions.outputs.COMBO_3_SUBNET }}
-        security-group-id: ${{ steps.parse-regions.outputs.COMBO_3_SG }}
-        ec2-volume-size: ${{ inputs.volume-size }}
-        pre-runner-script: ${{ inputs.pre-runner-script }}
-        iam-role-name: ${{ inputs.iam-role-name }}
-        aws-resource-tags: >
-          [
-            {"Key": "Name", "Value": "${{ inputs.runner-name-prefix }}"},
-            {"Key": "Repository", "Value": "${{ github.repository }}"},
-            {"Key": "Workflow", "Value": "${{ github.workflow }}"},
-            {"Key": "RunId", "Value": "${{ github.run_id }}"},
-            {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
-            {"Key": "SHA", "Value": "${{ github.sha }}"},
-            {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"},
-            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_3_REGION }}"}
-          ]
-
-    - name: Configure AWS credentials for Attempt 4
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 4 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' }}
-      id: aws-credentials-4
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: ${{ steps.parse-regions.outputs.COMBO_4_REGION }}
-        role-session-name: github-runner-session-4
-
-    - name: Start EC2 runner (Attempt 4)
-      id: start-ec2-runner-4
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 4 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' }}
-      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
-      continue-on-error: true
-      with:
-        mode: start
-        startup-quiet-period-seconds: 10
-        startup-retry-interval-seconds: 5
-        github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_4_AMI }}
-        ec2-instance-type: ${{ inputs.instance-type }}
-        market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-regions.outputs.COMBO_4_SUBNET }}
-        security-group-id: ${{ steps.parse-regions.outputs.COMBO_4_SG }}
-        ec2-volume-size: ${{ inputs.volume-size }}
-        pre-runner-script: ${{ inputs.pre-runner-script }}
-        iam-role-name: ${{ inputs.iam-role-name }}
-        aws-resource-tags: >
-          [
-            {"Key": "Name", "Value": "${{ inputs.runner-name-prefix }}"},
-            {"Key": "Repository", "Value": "${{ github.repository }}"},
-            {"Key": "Workflow", "Value": "${{ github.workflow }}"},
-            {"Key": "RunId", "Value": "${{ github.run_id }}"},
-            {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
-            {"Key": "SHA", "Value": "${{ github.sha }}"},
-            {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"},
-            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_4_REGION }}"}
-          ]
-
-    - name: Configure AWS credentials for Attempt 5
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 5 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' && steps.start-ec2-runner-4.outcome == 'failure' }}
-      id: aws-credentials-5
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: ${{ steps.parse-regions.outputs.COMBO_5_REGION }}
-        role-session-name: github-runner-session-5
-
-    - name: Start EC2 runner (Attempt 5)
-      id: start-ec2-runner-5
-      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 5 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' && steps.start-ec2-runner-4.outcome == 'failure' }}
-      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
-      continue-on-error: true
-      with:
-        mode: start
-        startup-quiet-period-seconds: 10
-        startup-retry-interval-seconds: 5
-        github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_5_AMI }}
-        ec2-instance-type: ${{ inputs.instance-type }}
-        market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-regions.outputs.COMBO_5_SUBNET }}
-        security-group-id: ${{ steps.parse-regions.outputs.COMBO_5_SG }}
-        ec2-volume-size: ${{ inputs.volume-size }}
-        pre-runner-script: ${{ inputs.pre-runner-script }}
-        iam-role-name: ${{ inputs.iam-role-name }}
-        aws-resource-tags: >
-          [
-            {"Key": "Name", "Value": "${{ inputs.runner-name-prefix }}"},
-            {"Key": "Repository", "Value": "${{ github.repository }}"},
-            {"Key": "Workflow", "Value": "${{ github.workflow }}"},
-            {"Key": "RunId", "Value": "${{ github.run_id }}"},
-            {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
-            {"Key": "SHA", "Value": "${{ github.sha }}"},
-            {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"},
-            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_5_REGION }}"}
+            {"Key": "Actor", "Value": "${{ github.actor }}"}
           ]
 
     - name: Collect outputs
       id: runner-outputs
       shell: bash
       run: |
-        # Determine which runner succeeded and set the outputs accordingly
-        if [ "${{ steps.start-ec2-runner-1.outcome }}" == "success" ]; then
-          echo "label=${{ steps.start-ec2-runner-1.outputs.label }}" >> $GITHUB_OUTPUT
-          echo "ec2-instance-id=${{ steps.start-ec2-runner-1.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "region=${{ steps.parse-regions.outputs.COMBO_1_REGION }}" >> $GITHUB_OUTPUT
-          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_1_REGION }}"
-        elif [ "${{ steps.start-ec2-runner-2.outcome }}" == "success" ]; then
-          echo "label=${{ steps.start-ec2-runner-2.outputs.label }}" >> $GITHUB_OUTPUT
-          echo "ec2-instance-id=${{ steps.start-ec2-runner-2.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "region=${{ steps.parse-regions.outputs.COMBO_2_REGION }}" >> $GITHUB_OUTPUT
-          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_2_REGION }}"
-        elif [ "${{ steps.start-ec2-runner-3.outcome }}" == "success" ]; then
-          echo "label=${{ steps.start-ec2-runner-3.outputs.label }}" >> $GITHUB_OUTPUT
-          echo "ec2-instance-id=${{ steps.start-ec2-runner-3.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "region=${{ steps.parse-regions.outputs.COMBO_3_REGION }}" >> $GITHUB_OUTPUT
-          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_3_REGION }}"
-        elif [ "${{ steps.start-ec2-runner-4.outcome }}" == "success" ]; then
-          echo "label=${{ steps.start-ec2-runner-4.outputs.label }}" >> $GITHUB_OUTPUT
-          echo "ec2-instance-id=${{ steps.start-ec2-runner-4.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "region=${{ steps.parse-regions.outputs.COMBO_4_REGION }}" >> $GITHUB_OUTPUT
-          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_4_REGION }}"
-        elif [ "${{ steps.start-ec2-runner-5.outcome }}" == "success" ]; then
-          echo "label=${{ steps.start-ec2-runner-5.outputs.label }}" >> $GITHUB_OUTPUT
-          echo "ec2-instance-id=${{ steps.start-ec2-runner-5.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "region=${{ steps.parse-regions.outputs.COMBO_5_REGION }}" >> $GITHUB_OUTPUT
-          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_5_REGION }}"
+        # Pass through the runner outputs
+        if [ -n "${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" ]; then
+          echo "label=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
+          echo "ec2-instance-id=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started"
         else
           echo "All runner attempts failed. Please check AWS capacity availability across regions."
           exit 1
-        fi
-
-    - name: Check if any runner succeeded
-      shell: bash
-      if: ${{ steps.runner-outputs.outcome == 'failure' }}
-      run: |
-        echo "All EC2 runner attempts failed across multiple regions and subnets. Please check AWS capacity availability or try a different instance type."
-        exit 1 
+        fi 

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -138,10 +138,10 @@ runs:
           SG="COMBO_${i}_SG"
           AMI="COMBO_${i}_AMI"
           
-          echo "Trying combination $i: Region=${{ steps.parse-regions.outputs[REGION] }}, Subnet=${{ steps.parse-regions.outputs[SUBNET] }}"
+          echo "Trying combination $i: Region=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]"), Subnet=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SUBNET\"]")"
           
           # Configure AWS credentials for this region
-          aws configure set region ${{ steps.parse-regions.outputs[REGION] }}
+          aws configure set region $(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]")
           
           # Set up temporary files for output capture
           TEMP_OUTPUT=$(mktemp)
@@ -150,7 +150,7 @@ runs:
           # Try to start a runner in this region/subnet
           aws sts get-caller-identity > /dev/null 2>&1
           if [ $? -ne 0 ]; then
-            echo "AWS credentials configuration failed for region ${{ steps.parse-regions.outputs[REGION] }}"
+            echo "AWS credentials configuration failed for region $(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]")"
             continue
           fi
           
@@ -158,16 +158,18 @@ runs:
           {
             # We'll use an inline script to set the AWS region and call the EC2 runner action
             # Note: This is a placeholder as we can't directly execute another composite action within bash
-            echo "REGION=${{ steps.parse-regions.outputs[REGION] }}" > $TEMP_OUTPUT
-            echo "SUBNET=${{ steps.parse-regions.outputs[SUBNET] }}" >> $TEMP_OUTPUT
-            echo "AMI=${{ steps.parse-regions.outputs[AMI] }}" >> $TEMP_OUTPUT
-            echo "SG=${{ steps.parse-regions.outputs[SG] }}" >> $TEMP_OUTPUT
+            echo "REGION=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]")" > $TEMP_OUTPUT
+            echo "SUBNET=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SUBNET\"]")" >> $TEMP_OUTPUT
+            echo "AMI=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_AMI\"]")" >> $TEMP_OUTPUT
+            echo "SG=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SG\"]")" >> $TEMP_OUTPUT
             
             # Simulate action run result (will be replaced with actual implementation)
             echo "This_combination_will_be_tried_by_the_multi-runner_step"
             
             # Mark this configuration for the multi-runner step
-            echo "CONFIG_${i}=region=${{ steps.parse-regions.outputs[REGION] }},subnet=${{ steps.parse-regions.outputs[SUBNET] }},sg=${{ steps.parse-regions.outputs[SG] }},ami=${{ steps.parse-regions.outputs[AMI] }}" >> $GITHUB_OUTPUT
+            CONFIG_KEY="CONFIG_${i}"
+            CONFIG_VALUE="region=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]"),subnet=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SUBNET\"]"),sg=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SG\"]"),ami=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_AMI\"]")"
+            echo "${CONFIG_KEY}=${CONFIG_VALUE}" >> $GITHUB_OUTPUT
           } > $TEMP_OUTPUT 2> $TEMP_ERROR
         done
     
@@ -183,10 +185,12 @@ runs:
         echo "We will try up to $MAX_COMBOS region/subnet combinations"
         
         for i in $(seq 1 $MAX_COMBOS); do
-          CONFIG="CONFIG_${i}"
-          if [[ -n "${{ steps.try-runners.outputs[CONFIG] }}" ]]; then
+          CONFIG_KEY="CONFIG_${i}"
+          CONFIG_VALUE=$(echo "${{ toJSON(steps.try-runners.outputs) }}" | jq -r ".[\"${CONFIG_KEY}\"] // \"\"")
+          
+          if [[ -n "$CONFIG_VALUE" ]]; then
             # Extract the region, subnet, security group, and AMI
-            IFS=',' read -r -a CONFIG_PARTS <<< "${{ steps.try-runners.outputs[CONFIG] }}"
+            IFS=',' read -r -a CONFIG_PARTS <<< "$CONFIG_VALUE"
             for part in "${CONFIG_PARTS[@]}"; do
               if [[ $part =~ ^region=(.*)$ ]]; then
                 echo "ATTEMPT_${i}_REGION=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: 'IAM role name for the EC2 instance'
     required: false
     default: ''
+  region-priority:
+    description: 'Ordered list of regions to try in priority order'
+    required: false
+    default: '["us-east-2", "us-west-2", "us-east-1", "eu-west-1"]'
   region-configs:
     description: 'Configuration for regions in JSON format with subnets and security groups'
     required: false
@@ -104,24 +108,36 @@ runs:
         echo "Region configs: ${{ inputs.region-configs }}"
         echo "AMI mappings: ${{ inputs.ami-mappings }}"
         echo "Image type: ${{ inputs.image-type }}"
+        echo "Region priority: ${{ inputs.region-priority }}"
         
         # Convert the JSON strings to files for jq processing
         echo '${{ inputs.region-configs }}' > /tmp/region_configs.json
         echo '${{ inputs.ami-mappings }}' > /tmp/ami_mappings.json
+        echo '${{ inputs.region-priority }}' > /tmp/region_priority.json
         
-        # Get all regions
-        REGIONS=$(jq -r 'keys | join(",")' /tmp/region_configs.json)
-        echo "Available regions: $REGIONS"
+        # Get prioritized regions
+        PRIORITY_REGIONS=$(jq -r 'join(",")' /tmp/region_priority.json)
+        echo "Prioritized regions: $PRIORITY_REGIONS"
+        
+        # Get all available regions from region configs
+        AVAILABLE_REGIONS=$(jq -r 'keys | join(",")' /tmp/region_configs.json)
+        echo "Available regions: $AVAILABLE_REGIONS"
         
         # Create an array to hold all AZ configurations
-        echo "Generating availability zone configurations for all regions..."
+        echo "Generating availability zone configurations in priority order..."
         echo "[" > /tmp/az_configs.json
         
         FIRST=true
         
-        # Loop through each region
-        for region in $(jq -r 'keys[]' /tmp/region_configs.json); do
+        # Process regions in priority order
+        for region in $(jq -r '.[]' /tmp/region_priority.json); do
           echo "Processing region: $region"
+          
+          # Check if region exists in region configs
+          if ! jq -e --arg r "$region" '.[$r]' /tmp/region_configs.json > /dev/null; then
+            echo "Warning: Region $region specified in priority list not found in region configs, skipping"
+            continue
+          fi
           
           # Get AMI ID for this region
           AMI_ID=$(jq -r --arg r "$region" --arg it "${{ inputs.image-type }}" '.[$it][$r]' /tmp/ami_mappings.json)

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: 'AWS region to create the instance in'
     required: true
   subnet-id:
-    description: 'AWS subnet ID for the instance'
+    description: 'AWS subnet ID(s) for the instance as a comma-separated list. Will try subnets in sequence after exhausting instance types.'
     required: true
   security-group-id:
     description: 'AWS security group ID for the instance'
@@ -69,27 +69,42 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         role-session-name: github-runner-session
 
-    - name: Parse instance types
-      id: parse-instance-types
+    - name: Parse instance types and subnet IDs
+      id: parse-combinations
       shell: bash
       run: |
-        # Split the comma-separated list into individual types
+        # Split the comma-separated lists into individual types and subnets
         IFS=',' read -ra TYPES <<< "${{ inputs.instance-type }}"
+        IFS=',' read -ra SUBNETS <<< "${{ inputs.subnet-id }}"
         
-        # Extract individual types
-        echo "TYPE_1=${TYPES[0]:-m7i.xlarge}" >> $GITHUB_OUTPUT
-        echo "TYPE_2=${TYPES[1]:-}" >> $GITHUB_OUTPUT
-        echo "TYPE_3=${TYPES[2]:-}" >> $GITHUB_OUTPUT
-        echo "TYPE_4=${TYPES[3]:-}" >> $GITHUB_OUTPUT
-        echo "TYPE_5=${TYPES[4]:-}" >> $GITHUB_OUTPUT
+        # Generate up to 5 combinations, prioritizing instance types first
+        count=0
+        for type in "${TYPES[@]}"; do
+          for subnet in "${SUBNETS[@]}"; do
+            count=$((count+1))
+            if [ $count -le 5 ]; then
+              echo "COMBO_${count}_TYPE=${type}" >> $GITHUB_OUTPUT
+              echo "COMBO_${count}_SUBNET=${subnet}" >> $GITHUB_OUTPUT
+            else
+              break 2  # Break both loops if we've reached 5 combinations
+            fi
+          done
+        done
         
-        echo "HAS_TYPE_2=$([ -n "${TYPES[1]:-}" ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
-        echo "HAS_TYPE_3=$([ -n "${TYPES[2]:-}" ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
-        echo "HAS_TYPE_4=$([ -n "${TYPES[3]:-}" ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
-        echo "HAS_TYPE_5=$([ -n "${TYPES[4]:-}" ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+        # Set flags for whether each combination exists
+        for i in {1..5}; do
+          if [ $i -le $count ]; then
+            echo "HAS_COMBO_${i}=true" >> $GITHUB_OUTPUT
+          else
+            echo "HAS_COMBO_${i}=false" >> $GITHUB_OUTPUT
+          fi
+        done
+        
+        echo "TOTAL_COMBOS=${count}" >> $GITHUB_OUTPUT
 
-    - name: Start EC2 runner (Type 1)
+    - name: Start EC2 runner (Combo 1)
       id: start-ec2-runner-1
+      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_1 == 'true' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -98,9 +113,9 @@ runs:
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
         ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-instance-types.outputs.TYPE_1 }}
+        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_1_TYPE }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ inputs.subnet-id }}
+        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_1_SUBNET }}
         security-group-id: ${{ inputs.security-group-id }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
@@ -117,9 +132,9 @@ runs:
             {"Key": "Actor", "Value": "${{ github.actor }}"}
           ]
 
-    - name: Start EC2 runner (Type 2)
+    - name: Start EC2 runner (Combo 2)
       id: start-ec2-runner-2
-      if: ${{ steps.parse-instance-types.outputs.HAS_TYPE_2 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' }}
+      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_2 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -128,9 +143,9 @@ runs:
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
         ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-instance-types.outputs.TYPE_2 }}
+        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_2_TYPE }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ inputs.subnet-id }}
+        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_2_SUBNET }}
         security-group-id: ${{ inputs.security-group-id }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
@@ -147,9 +162,9 @@ runs:
             {"Key": "Actor", "Value": "${{ github.actor }}"}
           ]
 
-    - name: Start EC2 runner (Type 3)
+    - name: Start EC2 runner (Combo 3)
       id: start-ec2-runner-3
-      if: ${{ steps.parse-instance-types.outputs.HAS_TYPE_3 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
+      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_3 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -158,9 +173,9 @@ runs:
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
         ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-instance-types.outputs.TYPE_3 }}
+        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_3_TYPE }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ inputs.subnet-id }}
+        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_3_SUBNET }}
         security-group-id: ${{ inputs.security-group-id }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
@@ -177,9 +192,9 @@ runs:
             {"Key": "Actor", "Value": "${{ github.actor }}"}
           ]
 
-    - name: Start EC2 runner (Type 4)
+    - name: Start EC2 runner (Combo 4)
       id: start-ec2-runner-4
-      if: ${{ steps.parse-instance-types.outputs.HAS_TYPE_4 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' }}
+      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_4 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -188,9 +203,9 @@ runs:
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
         ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-instance-types.outputs.TYPE_4 }}
+        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_4_TYPE }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ inputs.subnet-id }}
+        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_4_SUBNET }}
         security-group-id: ${{ inputs.security-group-id }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
@@ -207,9 +222,9 @@ runs:
             {"Key": "Actor", "Value": "${{ github.actor }}"}
           ]
 
-    - name: Start EC2 runner (Type 5)
+    - name: Start EC2 runner (Combo 5)
       id: start-ec2-runner-5
-      if: ${{ steps.parse-instance-types.outputs.HAS_TYPE_5 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' && steps.start-ec2-runner-4.outcome == 'failure' }}
+      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_5 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' && steps.start-ec2-runner-4.outcome == 'failure' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       with:
         mode: start
@@ -217,9 +232,9 @@ runs:
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
         ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-instance-types.outputs.TYPE_5 }}
+        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_5_TYPE }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ inputs.subnet-id }}
+        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_5_SUBNET }}
         security-group-id: ${{ inputs.security-group-id }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
@@ -238,7 +253,7 @@ runs:
 
     - name: Check if any runner succeeded
       shell: bash
-      if: ${{ steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' && steps.start-ec2-runner-4.outcome == 'failure' && steps.start-ec2-runner-5.outcome == 'failure' }}
+      if: ${{ steps.parse-combinations.outputs.TOTAL_COMBOS > 0 && steps.start-ec2-runner-1.outcome == 'failure' && (steps.parse-combinations.outputs.HAS_COMBO_2 == 'false' || steps.start-ec2-runner-2.outcome == 'failure') && (steps.parse-combinations.outputs.HAS_COMBO_3 == 'false' || steps.start-ec2-runner-3.outcome == 'failure') && (steps.parse-combinations.outputs.HAS_COMBO_4 == 'false' || steps.start-ec2-runner-4.outcome == 'failure') && (steps.parse-combinations.outputs.HAS_COMBO_5 == 'false' || steps.start-ec2-runner-5.outcome == 'failure') }}
       run: |
-        echo "All EC2 runner attempts failed. Please check AWS capacity availability or try different instance types."
+        echo "All EC2 runner attempts failed. Please check AWS capacity availability or try different instance types and subnet combinations."
         exit 1 

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -1,12 +1,16 @@
 name: 'AWS EC2 GitHub Runner'
-description: 'Start a self-hosted GitHub runner on AWS EC2'
+description: 'Start a self-hosted GitHub runner on AWS EC2 across multiple regions to find capacity'
 author: 'Memory Collector Team'
 
 inputs:
   instance-type:
-    description: 'EC2 instance types to use as a comma-separated list (e.g., "m7i.xlarge,c5.xlarge,r5.large"). Will try instances in sequence until one succeeds. If capacity is unavailable for the first type, it will try the next, and so on.'
+    description: 'EC2 instance type to use (e.g., "m7i.xlarge")'
     required: false
     default: 'm7i.xlarge'
+  image-type:
+    description: 'Image type identifier (e.g., "ubuntu-22.04")'
+    required: false
+    default: 'ubuntu-22.04'
   market-type:
     description: 'EC2 market type (spot or on-demand)'
     required: false
@@ -17,19 +21,6 @@ inputs:
   aws-role-arn:
     description: 'ARN of the AWS role to assume'
     required: true
-  aws-region:
-    description: 'AWS region to create the instance in'
-    required: true
-  subnet-id:
-    description: 'AWS subnet ID(s) for the instance as a comma-separated list. Will try subnets in sequence after exhausting instance types.'
-    required: true
-  security-group-id:
-    description: 'AWS security group ID for the instance'
-    required: true
-  aws-image-id:
-    description: 'Custom AMI ID (defaults to Ubuntu 22.04 LTS)'
-    required: false
-    default: 'ami-0884d2865dbe9de4b'  # Ubuntu 22.04 LTS in us-east-2
   volume-size:
     description: 'EC2 volume size in GB'
     required: false
@@ -50,61 +41,180 @@ inputs:
     description: 'IAM role name for the EC2 instance'
     required: false
     default: ''
+  region-configs:
+    description: 'Configuration for regions in JSON format with subnets and security groups'
+    required: false
+    default: >
+      {
+        "us-east-1": {
+          "security-group-id": "sg-0c0fb801b9d5afb42",
+          "subnets": ["subnet-0f218a8f807b24b43", "subnet-03760fcc21de05dcf", "subnet-07f33ad4e85154757", "subnet-06a59c6d0f0ae0acf", "subnet-01411d66f3c3b03ab", "subnet-0aacbbfdb4730c3ae"]
+        },
+        "us-west-2": {
+          "security-group-id": "sg-065a194f058366e19",
+          "subnets": ["subnet-03312d0e183ac6bd2", "subnet-0504fa9cacd9bece7", "subnet-07669de00a10cb45a", "subnet-027770cb161c110b2"]
+        },
+        "eu-west-1": {
+          "security-group-id": "sg-0eb8174e90d14cb8c",
+          "subnets": ["subnet-06bc798bc93c2d33d", "subnet-0e7134127c7fb199a", "subnet-0a2b8f49046507b4a"]
+        }
+      }
+  ami-mappings:
+    description: 'Mapping from image-type to region-specific AMI IDs'
+    required: false
+    default: >
+      {
+        "ubuntu-22.04": {
+          "us-east-1": "ami-0f9de6e2d2f067fca",
+          "us-west-2": "ami-03f8acd418785369b",
+          "eu-west-1": "ami-0f0c3baa60262d5b9"
+        },
+        "ubuntu-24.04": {
+          "us-east-1": "ami-084568db4383264d4",
+          "us-west-2": "ami-075686beab831bb7f",
+          "eu-west-1": "ami-0df368112825f8d8f"
+        }
+      }
 
 outputs:
   runner-label:
     description: 'The label of the created runner (for use in runs-on)'
-    value: ${{ steps.start-ec2-runner-5.outputs.label || steps.start-ec2-runner-4.outputs.label || steps.start-ec2-runner-3.outputs.label || steps.start-ec2-runner-2.outputs.label || steps.start-ec2-runner-1.outputs.label }}
+    value: ${{ steps.runner-outputs.outputs.label }}
   ec2-instance-id:
     description: 'The ID of the created EC2 instance'
-    value: ${{ steps.start-ec2-runner-5.outputs.ec2-instance-id || steps.start-ec2-runner-4.outputs.ec2-instance-id || steps.start-ec2-runner-3.outputs.ec2-instance-id || steps.start-ec2-runner-2.outputs.ec2-instance-id || steps.start-ec2-runner-1.outputs.ec2-instance-id }}
+    value: ${{ steps.runner-outputs.outputs.ec2-instance-id }}
+  region:
+    description: 'The AWS region where the instance was created'
+    value: ${{ steps.runner-outputs.outputs.region }}
 
 runs:
   using: 'composite'
   steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: ${{ inputs.aws-region }}
-        role-session-name: github-runner-session
-
-    - name: Parse instance types and subnet IDs
-      id: parse-combinations
+    - name: Parse Region Configurations
+      id: parse-regions
       shell: bash
       run: |
-        # Split the comma-separated lists into individual types and subnets
-        IFS=',' read -ra TYPES <<< "${{ inputs.instance-type }}"
-        IFS=',' read -ra SUBNETS <<< "${{ inputs.subnet-id }}"
+        # Parse the region configs
+        REGION_CONFIGS='${{ inputs.region-configs }}'
+        AMI_MAPPINGS='${{ inputs.ami-mappings }}'
+        IMAGE_TYPE='${{ inputs.image-type }}'
         
-        # Generate up to 5 combinations, prioritizing instance types first
-        count=0
-        for type in "${TYPES[@]}"; do
-          for subnet in "${SUBNETS[@]}"; do
-            count=$((count+1))
-            if [ $count -le 5 ]; then
-              echo "COMBO_${count}_TYPE=${type}" >> $GITHUB_OUTPUT
-              echo "COMBO_${count}_SUBNET=${subnet}" >> $GITHUB_OUTPUT
-            else
-              break 2  # Break both loops if we've reached 5 combinations
+        # Use jq to extract information
+        echo "REGIONS=$(echo $REGION_CONFIGS | jq -r 'keys | join(",")')" >> $GITHUB_OUTPUT
+        
+        # Count the total number of region+subnet combinations
+        COMBO_COUNT=0
+        for region in $(echo $REGION_CONFIGS | jq -r 'keys[]'); do
+          SECURITY_GROUP=$(echo $REGION_CONFIGS | jq -r --arg r "$region" '.[$r]["security-group-id"]')
+          SUBNETS=$(echo $REGION_CONFIGS | jq -r --arg r "$region" '.[$r].subnets[]')
+          AMI_ID=$(echo $AMI_MAPPINGS | jq -r --arg r "$region" --arg it "$IMAGE_TYPE" '.[$it][$r]')
+          
+          for subnet in $SUBNETS; do
+            COMBO_COUNT=$((COMBO_COUNT+1))
+            if [ $COMBO_COUNT -le 10 ]; then  # Limiting to 10 combinations
+              echo "COMBO_${COMBO_COUNT}_REGION=${region}" >> $GITHUB_OUTPUT
+              echo "COMBO_${COMBO_COUNT}_SUBNET=${subnet}" >> $GITHUB_OUTPUT
+              echo "COMBO_${COMBO_COUNT}_SG=${SECURITY_GROUP}" >> $GITHUB_OUTPUT
+              echo "COMBO_${COMBO_COUNT}_AMI=${AMI_ID}" >> $GITHUB_OUTPUT
             fi
           done
         done
         
-        # Set flags for whether each combination exists
-        for i in {1..5}; do
-          if [ $i -le $count ]; then
-            echo "HAS_COMBO_${i}=true" >> $GITHUB_OUTPUT
+        echo "TOTAL_COMBOS=$COMBO_COUNT" >> $GITHUB_OUTPUT
+        echo "MAX_COMBOS=$(( COMBO_COUNT > 10 ? 10 : COMBO_COUNT ))" >> $GITHUB_OUTPUT
+
+    - name: Try EC2 Runners Across Regions
+      id: try-runners
+      shell: bash
+      run: |
+        MAX_COMBOS="${{ steps.parse-regions.outputs.MAX_COMBOS }}"
+        
+        # Initialize variables to track successful run
+        echo "SUCCESS=false" >> $GITHUB_ENV
+        
+        for i in $(seq 1 $MAX_COMBOS); do
+          REGION="COMBO_${i}_REGION"
+          SUBNET="COMBO_${i}_SUBNET"
+          SG="COMBO_${i}_SG"
+          AMI="COMBO_${i}_AMI"
+          
+          echo "Trying combination $i: Region=${{ steps.parse-regions.outputs[REGION] }}, Subnet=${{ steps.parse-regions.outputs[SUBNET] }}"
+          
+          # Configure AWS credentials for this region
+          aws configure set region ${{ steps.parse-regions.outputs[REGION] }}
+          
+          # Set up temporary files for output capture
+          TEMP_OUTPUT=$(mktemp)
+          TEMP_ERROR=$(mktemp)
+          
+          # Try to start a runner in this region/subnet
+          aws sts get-caller-identity > /dev/null 2>&1
+          if [ $? -ne 0 ]; then
+            echo "AWS credentials configuration failed for region ${{ steps.parse-regions.outputs[REGION] }}"
+            continue
+          fi
+          
+          # Run the GitHub Action for this combination
+          {
+            # We'll use an inline script to set the AWS region and call the EC2 runner action
+            # Note: This is a placeholder as we can't directly execute another composite action within bash
+            echo "REGION=${{ steps.parse-regions.outputs[REGION] }}" > $TEMP_OUTPUT
+            echo "SUBNET=${{ steps.parse-regions.outputs[SUBNET] }}" >> $TEMP_OUTPUT
+            echo "AMI=${{ steps.parse-regions.outputs[AMI] }}" >> $TEMP_OUTPUT
+            echo "SG=${{ steps.parse-regions.outputs[SG] }}" >> $TEMP_OUTPUT
+            
+            # Simulate action run result (will be replaced with actual implementation)
+            echo "This_combination_will_be_tried_by_the_multi-runner_step"
+            
+            # Mark this configuration for the multi-runner step
+            echo "CONFIG_${i}=region=${{ steps.parse-regions.outputs[REGION] }},subnet=${{ steps.parse-regions.outputs[SUBNET] }},sg=${{ steps.parse-regions.outputs[SG] }},ami=${{ steps.parse-regions.outputs[AMI] }}" >> $GITHUB_OUTPUT
+          } > $TEMP_OUTPUT 2> $TEMP_ERROR
+        done
+    
+    # The following steps will be executed for each region/subnet combination
+    # We'll use a multi-runner approach with 10 possible combinations
+    
+    - name: Set up Multi-Region Runner Attempts
+      id: setup-attempts
+      shell: bash
+      run: |
+        # Set up the number of attempts we'll make
+        MAX_COMBOS="${{ steps.parse-regions.outputs.MAX_COMBOS }}"
+        echo "We will try up to $MAX_COMBOS region/subnet combinations"
+        
+        for i in $(seq 1 $MAX_COMBOS); do
+          CONFIG="CONFIG_${i}"
+          if [[ -n "${{ steps.try-runners.outputs[CONFIG] }}" ]]; then
+            # Extract the region, subnet, security group, and AMI
+            IFS=',' read -r -a CONFIG_PARTS <<< "${{ steps.try-runners.outputs[CONFIG] }}"
+            for part in "${CONFIG_PARTS[@]}"; do
+              if [[ $part =~ ^region=(.*)$ ]]; then
+                echo "ATTEMPT_${i}_REGION=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+              elif [[ $part =~ ^subnet=(.*)$ ]]; then
+                echo "ATTEMPT_${i}_SUBNET=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+              elif [[ $part =~ ^sg=(.*)$ ]]; then
+                echo "ATTEMPT_${i}_SG=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+              elif [[ $part =~ ^ami=(.*)$ ]]; then
+                echo "ATTEMPT_${i}_AMI=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+              fi
+            done
+            echo "ATTEMPT_${i}=true" >> $GITHUB_OUTPUT
           else
-            echo "HAS_COMBO_${i}=false" >> $GITHUB_OUTPUT
+            echo "ATTEMPT_${i}=false" >> $GITHUB_OUTPUT
           fi
         done
-        
-        echo "TOTAL_COMBOS=${count}" >> $GITHUB_OUTPUT
 
-    - name: Start EC2 runner (Combo 1)
+    # Now we define steps for each attempt
+    - name: Configure AWS credentials for Multi-Region
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        aws-region: ${{ steps.setup-attempts.outputs.ATTEMPT_1_REGION || 'us-east-1' }}
+        role-session-name: github-runner-session
+
+    - name: Start EC2 runner (Attempt 1)
       id: start-ec2-runner-1
-      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_1 == 'true' }}
+      if: ${{ steps.setup-attempts.outputs.ATTEMPT_1 == 'true' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -112,11 +222,11 @@ runs:
         startup-quiet-period-seconds: 10
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_1_TYPE }}
+        ec2-image-id: ${{ steps.setup-attempts.outputs.ATTEMPT_1_AMI }}
+        ec2-instance-type: ${{ inputs.instance-type }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_1_SUBNET }}
-        security-group-id: ${{ inputs.security-group-id }}
+        subnet-id: ${{ steps.setup-attempts.outputs.ATTEMPT_1_SUBNET }}
+        security-group-id: ${{ steps.setup-attempts.outputs.ATTEMPT_1_SG }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
         iam-role-name: ${{ inputs.iam-role-name }}
@@ -129,12 +239,21 @@ runs:
             {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
             {"Key": "SHA", "Value": "${{ github.sha }}"},
             {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"}
+            {"Key": "Actor", "Value": "${{ github.actor }}"},
+            {"Key": "Region", "Value": "${{ steps.setup-attempts.outputs.ATTEMPT_1_REGION }}"}
           ]
 
-    - name: Start EC2 runner (Combo 2)
+    - name: Configure AWS credentials for Attempt 2
+      if: ${{ steps.setup-attempts.outputs.ATTEMPT_2 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' }}
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        aws-region: ${{ steps.setup-attempts.outputs.ATTEMPT_2_REGION }}
+        role-session-name: github-runner-session
+
+    - name: Start EC2 runner (Attempt 2)
       id: start-ec2-runner-2
-      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_2 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' }}
+      if: ${{ steps.setup-attempts.outputs.ATTEMPT_2 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -142,11 +261,11 @@ runs:
         startup-quiet-period-seconds: 10
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_2_TYPE }}
+        ec2-image-id: ${{ steps.setup-attempts.outputs.ATTEMPT_2_AMI }}
+        ec2-instance-type: ${{ inputs.instance-type }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_2_SUBNET }}
-        security-group-id: ${{ inputs.security-group-id }}
+        subnet-id: ${{ steps.setup-attempts.outputs.ATTEMPT_2_SUBNET }}
+        security-group-id: ${{ steps.setup-attempts.outputs.ATTEMPT_2_SG }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
         iam-role-name: ${{ inputs.iam-role-name }}
@@ -159,12 +278,25 @@ runs:
             {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
             {"Key": "SHA", "Value": "${{ github.sha }}"},
             {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"}
+            {"Key": "Actor", "Value": "${{ github.actor }}"},
+            {"Key": "Region", "Value": "${{ steps.setup-attempts.outputs.ATTEMPT_2_REGION }}"}
           ]
 
-    - name: Start EC2 runner (Combo 3)
+    # Continue with more attempts as needed (3-10)
+    # For brevity, I'm including just a few, but you can expand this pattern
+    # The pattern continues for attempts 3-10 following the same structure
+
+    - name: Configure AWS credentials for Attempt 3
+      if: ${{ steps.setup-attempts.outputs.ATTEMPT_3 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        aws-region: ${{ steps.setup-attempts.outputs.ATTEMPT_3_REGION }}
+        role-session-name: github-runner-session
+
+    - name: Start EC2 runner (Attempt 3)
       id: start-ec2-runner-3
-      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_3 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
+      if: ${{ steps.setup-attempts.outputs.ATTEMPT_3 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -172,11 +304,11 @@ runs:
         startup-quiet-period-seconds: 10
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_3_TYPE }}
+        ec2-image-id: ${{ steps.setup-attempts.outputs.ATTEMPT_3_AMI }}
+        ec2-instance-type: ${{ inputs.instance-type }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_3_SUBNET }}
-        security-group-id: ${{ inputs.security-group-id }}
+        subnet-id: ${{ steps.setup-attempts.outputs.ATTEMPT_3_SUBNET }}
+        security-group-id: ${{ steps.setup-attempts.outputs.ATTEMPT_3_SG }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
         iam-role-name: ${{ inputs.iam-role-name }}
@@ -189,71 +321,38 @@ runs:
             {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
             {"Key": "SHA", "Value": "${{ github.sha }}"},
             {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"}
+            {"Key": "Actor", "Value": "${{ github.actor }}"},
+            {"Key": "Region", "Value": "${{ steps.setup-attempts.outputs.ATTEMPT_3_REGION }}"}
           ]
 
-    - name: Start EC2 runner (Combo 4)
-      id: start-ec2-runner-4
-      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_4 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' }}
-      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
-      continue-on-error: true
-      with:
-        mode: start
-        startup-quiet-period-seconds: 10
-        startup-retry-interval-seconds: 5
-        github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_4_TYPE }}
-        market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_4_SUBNET }}
-        security-group-id: ${{ inputs.security-group-id }}
-        ec2-volume-size: ${{ inputs.volume-size }}
-        pre-runner-script: ${{ inputs.pre-runner-script }}
-        iam-role-name: ${{ inputs.iam-role-name }}
-        aws-resource-tags: >
-          [
-            {"Key": "Name", "Value": "${{ inputs.runner-name-prefix }}"},
-            {"Key": "Repository", "Value": "${{ github.repository }}"},
-            {"Key": "Workflow", "Value": "${{ github.workflow }}"},
-            {"Key": "RunId", "Value": "${{ github.run_id }}"},
-            {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
-            {"Key": "SHA", "Value": "${{ github.sha }}"},
-            {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"}
-          ]
-
-    - name: Start EC2 runner (Combo 5)
-      id: start-ec2-runner-5
-      if: ${{ steps.parse-combinations.outputs.HAS_COMBO_5 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' && steps.start-ec2-runner-4.outcome == 'failure' }}
-      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
-      with:
-        mode: start
-        startup-quiet-period-seconds: 10
-        startup-retry-interval-seconds: 5
-        github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ inputs.aws-image-id }}
-        ec2-instance-type: ${{ steps.parse-combinations.outputs.COMBO_5_TYPE }}
-        market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.parse-combinations.outputs.COMBO_5_SUBNET }}
-        security-group-id: ${{ inputs.security-group-id }}
-        ec2-volume-size: ${{ inputs.volume-size }}
-        pre-runner-script: ${{ inputs.pre-runner-script }}
-        iam-role-name: ${{ inputs.iam-role-name }}
-        aws-resource-tags: >
-          [
-            {"Key": "Name", "Value": "${{ inputs.runner-name-prefix }}"},
-            {"Key": "Repository", "Value": "${{ github.repository }}"},
-            {"Key": "Workflow", "Value": "${{ github.workflow }}"},
-            {"Key": "RunId", "Value": "${{ github.run_id }}"},
-            {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
-            {"Key": "SHA", "Value": "${{ github.sha }}"},
-            {"Key": "Branch", "Value": "${{ github.ref_name }}"},
-            {"Key": "Actor", "Value": "${{ github.actor }}"}
-          ]
+    - name: Collect outputs
+      id: runner-outputs
+      shell: bash
+      run: |
+        # Determine which runner succeeded and set the outputs accordingly
+        if [ "${{ steps.start-ec2-runner-1.outcome }}" == "success" ]; then
+          echo "label=${{ steps.start-ec2-runner-1.outputs.label }}" >> $GITHUB_OUTPUT
+          echo "ec2-instance-id=${{ steps.start-ec2-runner-1.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          echo "region=${{ steps.setup-attempts.outputs.ATTEMPT_1_REGION }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started in ${{ steps.setup-attempts.outputs.ATTEMPT_1_REGION }}"
+        elif [ "${{ steps.start-ec2-runner-2.outcome }}" == "success" ]; then
+          echo "label=${{ steps.start-ec2-runner-2.outputs.label }}" >> $GITHUB_OUTPUT
+          echo "ec2-instance-id=${{ steps.start-ec2-runner-2.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          echo "region=${{ steps.setup-attempts.outputs.ATTEMPT_2_REGION }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started in ${{ steps.setup-attempts.outputs.ATTEMPT_2_REGION }}"
+        elif [ "${{ steps.start-ec2-runner-3.outcome }}" == "success" ]; then
+          echo "label=${{ steps.start-ec2-runner-3.outputs.label }}" >> $GITHUB_OUTPUT
+          echo "ec2-instance-id=${{ steps.start-ec2-runner-3.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          echo "region=${{ steps.setup-attempts.outputs.ATTEMPT_3_REGION }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started in ${{ steps.setup-attempts.outputs.ATTEMPT_3_REGION }}"
+        else
+          echo "All runner attempts failed. Please check AWS capacity availability across regions."
+          exit 1
+        fi
 
     - name: Check if any runner succeeded
       shell: bash
-      if: ${{ steps.parse-combinations.outputs.TOTAL_COMBOS > 0 && steps.start-ec2-runner-1.outcome == 'failure' && (steps.parse-combinations.outputs.HAS_COMBO_2 == 'false' || steps.start-ec2-runner-2.outcome == 'failure') && (steps.parse-combinations.outputs.HAS_COMBO_3 == 'false' || steps.start-ec2-runner-3.outcome == 'failure') && (steps.parse-combinations.outputs.HAS_COMBO_4 == 'false' || steps.start-ec2-runner-4.outcome == 'failure') && (steps.parse-combinations.outputs.HAS_COMBO_5 == 'false' || steps.start-ec2-runner-5.outcome == 'failure') }}
+      if: ${{ steps.runner-outputs.outcome == 'failure' }}
       run: |
-        echo "All EC2 runner attempts failed. Please check AWS capacity availability or try different instance types and subnet combinations."
+        echo "All EC2 runner attempts failed across multiple regions and subnets. Please check AWS capacity availability or try a different instance type."
         exit 1 

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -95,22 +95,41 @@ runs:
       shell: bash
       run: |
         # Parse the region configs
-        REGION_CONFIGS='${{ inputs.region-configs }}'
-        AMI_MAPPINGS='${{ inputs.ami-mappings }}'
-        IMAGE_TYPE='${{ inputs.image-type }}'
+        echo "Region configs: ${{ inputs.region-configs }}"
+        echo "AMI mappings: ${{ inputs.ami-mappings }}"
+        echo "Image type: ${{ inputs.image-type }}"
+        
+        # Convert the JSON strings to files for jq processing
+        echo '${{ inputs.region-configs }}' > /tmp/region_configs.json
+        echo '${{ inputs.ami-mappings }}' > /tmp/ami_mappings.json
         
         # Use jq to extract information
-        echo "REGIONS=$(echo $REGION_CONFIGS | jq -r 'keys | join(",")')" >> $GITHUB_OUTPUT
+        REGIONS=$(jq -r 'keys | join(",")' /tmp/region_configs.json)
+        echo "REGIONS=${REGIONS}" >> $GITHUB_OUTPUT
         
         # Count the total number of region+subnet combinations
         COMBO_COUNT=0
-        for region in $(echo $REGION_CONFIGS | jq -r 'keys[]'); do
-          SECURITY_GROUP=$(echo $REGION_CONFIGS | jq -r --arg r "$region" '.[$r]["security-group-id"]')
-          SUBNETS=$(echo $REGION_CONFIGS | jq -r --arg r "$region" '.[$r].subnets[]')
-          AMI_ID=$(echo $AMI_MAPPINGS | jq -r --arg r "$region" --arg it "$IMAGE_TYPE" '.[$it][$r]')
+        
+        # Loop through each region using jq
+        for region in $(jq -r 'keys[]' /tmp/region_configs.json); do
+          echo "Processing region: ${region}"
           
+          # Get security group for this region
+          SECURITY_GROUP=$(jq -r --arg r "${region}" '.[$r]["security-group-id"]' /tmp/region_configs.json)
+          echo "Security group for ${region}: ${SECURITY_GROUP}"
+          
+          # Get subnets for this region
+          SUBNETS=$(jq -r --arg r "${region}" '.[$r].subnets[]' /tmp/region_configs.json)
+          
+          # Get AMI ID for this region and image type
+          AMI_ID=$(jq -r --arg r "${region}" --arg it "${{ inputs.image-type }}" '.[$it][$r]' /tmp/ami_mappings.json)
+          echo "AMI ID for ${region} with image type ${{ inputs.image-type }}: ${AMI_ID}"
+          
+          # Process each subnet in this region
           for subnet in $SUBNETS; do
             COMBO_COUNT=$((COMBO_COUNT+1))
+            echo "Found combination ${COMBO_COUNT}: Region=${region}, Subnet=${subnet}, SG=${SECURITY_GROUP}, AMI=${AMI_ID}"
+            
             if [ $COMBO_COUNT -le 10 ]; then  # Limiting to 10 combinations
               echo "COMBO_${COMBO_COUNT}_REGION=${region}" >> $GITHUB_OUTPUT
               echo "COMBO_${COMBO_COUNT}_SUBNET=${subnet}" >> $GITHUB_OUTPUT
@@ -120,105 +139,37 @@ runs:
           done
         done
         
-        echo "TOTAL_COMBOS=$COMBO_COUNT" >> $GITHUB_OUTPUT
+        echo "Total combinations found: ${COMBO_COUNT}"
+        echo "TOTAL_COMBOS=${COMBO_COUNT}" >> $GITHUB_OUTPUT
         echo "MAX_COMBOS=$(( COMBO_COUNT > 10 ? 10 : COMBO_COUNT ))" >> $GITHUB_OUTPUT
 
-    - name: Try EC2 Runners Across Regions
-      id: try-runners
+    - name: Display Region Combinations
       shell: bash
       run: |
+        echo "Available region combinations:"
         MAX_COMBOS="${{ steps.parse-regions.outputs.MAX_COMBOS }}"
         
-        # Initialize variables to track successful run
-        echo "SUCCESS=false" >> $GITHUB_ENV
-        
         for i in $(seq 1 $MAX_COMBOS); do
-          REGION="COMBO_${i}_REGION"
-          SUBNET="COMBO_${i}_SUBNET"
-          SG="COMBO_${i}_SG"
-          AMI="COMBO_${i}_AMI"
-          
-          echo "Trying combination $i: Region=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]"), Subnet=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SUBNET\"]")"
-          
-          # Configure AWS credentials for this region
-          aws configure set region $(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]")
-          
-          # Set up temporary files for output capture
-          TEMP_OUTPUT=$(mktemp)
-          TEMP_ERROR=$(mktemp)
-          
-          # Try to start a runner in this region/subnet
-          aws sts get-caller-identity > /dev/null 2>&1
-          if [ $? -ne 0 ]; then
-            echo "AWS credentials configuration failed for region $(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]")"
-            continue
-          fi
-          
-          # Run the GitHub Action for this combination
-          {
-            # We'll use an inline script to set the AWS region and call the EC2 runner action
-            # Note: This is a placeholder as we can't directly execute another composite action within bash
-            echo "REGION=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]")" > $TEMP_OUTPUT
-            echo "SUBNET=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SUBNET\"]")" >> $TEMP_OUTPUT
-            echo "AMI=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_AMI\"]")" >> $TEMP_OUTPUT
-            echo "SG=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SG\"]")" >> $TEMP_OUTPUT
-            
-            # Simulate action run result (will be replaced with actual implementation)
-            echo "This_combination_will_be_tried_by_the_multi-runner_step"
-            
-            # Mark this configuration for the multi-runner step
-            CONFIG_KEY="CONFIG_${i}"
-            CONFIG_VALUE="region=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_REGION\"]"),subnet=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SUBNET\"]"),sg=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_SG\"]"),ami=$(echo "${{ toJSON(steps.parse-regions.outputs) }}" | jq -r ".[\"COMBO_${i}_AMI\"]")"
-            echo "${CONFIG_KEY}=${CONFIG_VALUE}" >> $GITHUB_OUTPUT
-          } > $TEMP_OUTPUT 2> $TEMP_ERROR
-        done
-    
-    # The following steps will be executed for each region/subnet combination
-    # We'll use a multi-runner approach with 10 possible combinations
-    
-    - name: Set up Multi-Region Runner Attempts
-      id: setup-attempts
-      shell: bash
-      run: |
-        # Set up the number of attempts we'll make
-        MAX_COMBOS="${{ steps.parse-regions.outputs.MAX_COMBOS }}"
-        echo "We will try up to $MAX_COMBOS region/subnet combinations"
-        
-        for i in $(seq 1 $MAX_COMBOS); do
-          CONFIG_KEY="CONFIG_${i}"
-          CONFIG_VALUE=$(echo "${{ toJSON(steps.try-runners.outputs) }}" | jq -r ".[\"${CONFIG_KEY}\"] // \"\"")
-          
-          if [[ -n "$CONFIG_VALUE" ]]; then
-            # Extract the region, subnet, security group, and AMI
-            IFS=',' read -r -a CONFIG_PARTS <<< "$CONFIG_VALUE"
-            for part in "${CONFIG_PARTS[@]}"; do
-              if [[ $part =~ ^region=(.*)$ ]]; then
-                echo "ATTEMPT_${i}_REGION=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
-              elif [[ $part =~ ^subnet=(.*)$ ]]; then
-                echo "ATTEMPT_${i}_SUBNET=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
-              elif [[ $part =~ ^sg=(.*)$ ]]; then
-                echo "ATTEMPT_${i}_SG=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
-              elif [[ $part =~ ^ami=(.*)$ ]]; then
-                echo "ATTEMPT_${i}_AMI=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
-              fi
-            done
-            echo "ATTEMPT_${i}=true" >> $GITHUB_OUTPUT
-          else
-            echo "ATTEMPT_${i}=false" >> $GITHUB_OUTPUT
-          fi
+          echo "Combination $i:"
+          echo "  Region: ${{ steps.parse-regions.outputs.COMBO_${i}_REGION }}"
+          echo "  Subnet: ${{ steps.parse-regions.outputs.COMBO_${i}_SUBNET }}"
+          echo "  Security Group: ${{ steps.parse-regions.outputs.COMBO_${i}_SG }}"
+          echo "  AMI: ${{ steps.parse-regions.outputs.COMBO_${i}_AMI }}"
         done
 
-    # Now we define steps for each attempt
-    - name: Configure AWS credentials for Multi-Region
+    # Now we define steps for each combination using proper AWS actions
+    - name: Configure AWS credentials for Attempt 1
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 1 }}
+      id: aws-credentials-1
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: ${{ steps.setup-attempts.outputs.ATTEMPT_1_REGION || 'us-east-1' }}
-        role-session-name: github-runner-session
+        aws-region: ${{ steps.parse-regions.outputs.COMBO_1_REGION }}
+        role-session-name: github-runner-session-1
 
     - name: Start EC2 runner (Attempt 1)
       id: start-ec2-runner-1
-      if: ${{ steps.setup-attempts.outputs.ATTEMPT_1 == 'true' }}
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 1 }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -226,11 +177,11 @@ runs:
         startup-quiet-period-seconds: 10
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ steps.setup-attempts.outputs.ATTEMPT_1_AMI }}
+        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_1_AMI }}
         ec2-instance-type: ${{ inputs.instance-type }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.setup-attempts.outputs.ATTEMPT_1_SUBNET }}
-        security-group-id: ${{ steps.setup-attempts.outputs.ATTEMPT_1_SG }}
+        subnet-id: ${{ steps.parse-regions.outputs.COMBO_1_SUBNET }}
+        security-group-id: ${{ steps.parse-regions.outputs.COMBO_1_SG }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
         iam-role-name: ${{ inputs.iam-role-name }}
@@ -244,20 +195,21 @@ runs:
             {"Key": "SHA", "Value": "${{ github.sha }}"},
             {"Key": "Branch", "Value": "${{ github.ref_name }}"},
             {"Key": "Actor", "Value": "${{ github.actor }}"},
-            {"Key": "Region", "Value": "${{ steps.setup-attempts.outputs.ATTEMPT_1_REGION }}"}
+            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_1_REGION }}"}
           ]
 
     - name: Configure AWS credentials for Attempt 2
-      if: ${{ steps.setup-attempts.outputs.ATTEMPT_2 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' }}
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 2 && steps.start-ec2-runner-1.outcome == 'failure' }}
+      id: aws-credentials-2
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: ${{ steps.setup-attempts.outputs.ATTEMPT_2_REGION }}
-        role-session-name: github-runner-session
+        aws-region: ${{ steps.parse-regions.outputs.COMBO_2_REGION }}
+        role-session-name: github-runner-session-2
 
     - name: Start EC2 runner (Attempt 2)
       id: start-ec2-runner-2
-      if: ${{ steps.setup-attempts.outputs.ATTEMPT_2 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' }}
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 2 && steps.start-ec2-runner-1.outcome == 'failure' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -265,11 +217,11 @@ runs:
         startup-quiet-period-seconds: 10
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ steps.setup-attempts.outputs.ATTEMPT_2_AMI }}
+        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_2_AMI }}
         ec2-instance-type: ${{ inputs.instance-type }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.setup-attempts.outputs.ATTEMPT_2_SUBNET }}
-        security-group-id: ${{ steps.setup-attempts.outputs.ATTEMPT_2_SG }}
+        subnet-id: ${{ steps.parse-regions.outputs.COMBO_2_SUBNET }}
+        security-group-id: ${{ steps.parse-regions.outputs.COMBO_2_SG }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
         iam-role-name: ${{ inputs.iam-role-name }}
@@ -283,24 +235,21 @@ runs:
             {"Key": "SHA", "Value": "${{ github.sha }}"},
             {"Key": "Branch", "Value": "${{ github.ref_name }}"},
             {"Key": "Actor", "Value": "${{ github.actor }}"},
-            {"Key": "Region", "Value": "${{ steps.setup-attempts.outputs.ATTEMPT_2_REGION }}"}
+            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_2_REGION }}"}
           ]
 
-    # Continue with more attempts as needed (3-10)
-    # For brevity, I'm including just a few, but you can expand this pattern
-    # The pattern continues for attempts 3-10 following the same structure
-
     - name: Configure AWS credentials for Attempt 3
-      if: ${{ steps.setup-attempts.outputs.ATTEMPT_3 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 3 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
+      id: aws-credentials-3
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: ${{ steps.setup-attempts.outputs.ATTEMPT_3_REGION }}
-        role-session-name: github-runner-session
+        aws-region: ${{ steps.parse-regions.outputs.COMBO_3_REGION }}
+        role-session-name: github-runner-session-3
 
     - name: Start EC2 runner (Attempt 3)
       id: start-ec2-runner-3
-      if: ${{ steps.setup-attempts.outputs.ATTEMPT_3 == 'true' && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 3 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' }}
       uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
       continue-on-error: true
       with:
@@ -308,11 +257,11 @@ runs:
         startup-quiet-period-seconds: 10
         startup-retry-interval-seconds: 5
         github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ steps.setup-attempts.outputs.ATTEMPT_3_AMI }}
+        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_3_AMI }}
         ec2-instance-type: ${{ inputs.instance-type }}
         market-type: ${{ inputs.market-type }}
-        subnet-id: ${{ steps.setup-attempts.outputs.ATTEMPT_3_SUBNET }}
-        security-group-id: ${{ steps.setup-attempts.outputs.ATTEMPT_3_SG }}
+        subnet-id: ${{ steps.parse-regions.outputs.COMBO_3_SUBNET }}
+        security-group-id: ${{ steps.parse-regions.outputs.COMBO_3_SG }}
         ec2-volume-size: ${{ inputs.volume-size }}
         pre-runner-script: ${{ inputs.pre-runner-script }}
         iam-role-name: ${{ inputs.iam-role-name }}
@@ -326,7 +275,87 @@ runs:
             {"Key": "SHA", "Value": "${{ github.sha }}"},
             {"Key": "Branch", "Value": "${{ github.ref_name }}"},
             {"Key": "Actor", "Value": "${{ github.actor }}"},
-            {"Key": "Region", "Value": "${{ steps.setup-attempts.outputs.ATTEMPT_3_REGION }}"}
+            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_3_REGION }}"}
+          ]
+
+    - name: Configure AWS credentials for Attempt 4
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 4 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' }}
+      id: aws-credentials-4
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        aws-region: ${{ steps.parse-regions.outputs.COMBO_4_REGION }}
+        role-session-name: github-runner-session-4
+
+    - name: Start EC2 runner (Attempt 4)
+      id: start-ec2-runner-4
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 4 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' }}
+      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
+      continue-on-error: true
+      with:
+        mode: start
+        startup-quiet-period-seconds: 10
+        startup-retry-interval-seconds: 5
+        github-token: ${{ inputs.github-token }}
+        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_4_AMI }}
+        ec2-instance-type: ${{ inputs.instance-type }}
+        market-type: ${{ inputs.market-type }}
+        subnet-id: ${{ steps.parse-regions.outputs.COMBO_4_SUBNET }}
+        security-group-id: ${{ steps.parse-regions.outputs.COMBO_4_SG }}
+        ec2-volume-size: ${{ inputs.volume-size }}
+        pre-runner-script: ${{ inputs.pre-runner-script }}
+        iam-role-name: ${{ inputs.iam-role-name }}
+        aws-resource-tags: >
+          [
+            {"Key": "Name", "Value": "${{ inputs.runner-name-prefix }}"},
+            {"Key": "Repository", "Value": "${{ github.repository }}"},
+            {"Key": "Workflow", "Value": "${{ github.workflow }}"},
+            {"Key": "RunId", "Value": "${{ github.run_id }}"},
+            {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
+            {"Key": "SHA", "Value": "${{ github.sha }}"},
+            {"Key": "Branch", "Value": "${{ github.ref_name }}"},
+            {"Key": "Actor", "Value": "${{ github.actor }}"},
+            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_4_REGION }}"}
+          ]
+
+    - name: Configure AWS credentials for Attempt 5
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 5 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' && steps.start-ec2-runner-4.outcome == 'failure' }}
+      id: aws-credentials-5
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        aws-region: ${{ steps.parse-regions.outputs.COMBO_5_REGION }}
+        role-session-name: github-runner-session-5
+
+    - name: Start EC2 runner (Attempt 5)
+      id: start-ec2-runner-5
+      if: ${{ steps.parse-regions.outputs.MAX_COMBOS >= 5 && steps.start-ec2-runner-1.outcome == 'failure' && steps.start-ec2-runner-2.outcome == 'failure' && steps.start-ec2-runner-3.outcome == 'failure' && steps.start-ec2-runner-4.outcome == 'failure' }}
+      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
+      continue-on-error: true
+      with:
+        mode: start
+        startup-quiet-period-seconds: 10
+        startup-retry-interval-seconds: 5
+        github-token: ${{ inputs.github-token }}
+        ec2-image-id: ${{ steps.parse-regions.outputs.COMBO_5_AMI }}
+        ec2-instance-type: ${{ inputs.instance-type }}
+        market-type: ${{ inputs.market-type }}
+        subnet-id: ${{ steps.parse-regions.outputs.COMBO_5_SUBNET }}
+        security-group-id: ${{ steps.parse-regions.outputs.COMBO_5_SG }}
+        ec2-volume-size: ${{ inputs.volume-size }}
+        pre-runner-script: ${{ inputs.pre-runner-script }}
+        iam-role-name: ${{ inputs.iam-role-name }}
+        aws-resource-tags: >
+          [
+            {"Key": "Name", "Value": "${{ inputs.runner-name-prefix }}"},
+            {"Key": "Repository", "Value": "${{ github.repository }}"},
+            {"Key": "Workflow", "Value": "${{ github.workflow }}"},
+            {"Key": "RunId", "Value": "${{ github.run_id }}"},
+            {"Key": "RunNumber", "Value": "${{ github.run_number }}"},
+            {"Key": "SHA", "Value": "${{ github.sha }}"},
+            {"Key": "Branch", "Value": "${{ github.ref_name }}"},
+            {"Key": "Actor", "Value": "${{ github.actor }}"},
+            {"Key": "Region", "Value": "${{ steps.parse-regions.outputs.COMBO_5_REGION }}"}
           ]
 
     - name: Collect outputs
@@ -337,18 +366,28 @@ runs:
         if [ "${{ steps.start-ec2-runner-1.outcome }}" == "success" ]; then
           echo "label=${{ steps.start-ec2-runner-1.outputs.label }}" >> $GITHUB_OUTPUT
           echo "ec2-instance-id=${{ steps.start-ec2-runner-1.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "region=${{ steps.setup-attempts.outputs.ATTEMPT_1_REGION }}" >> $GITHUB_OUTPUT
-          echo "Runner successfully started in ${{ steps.setup-attempts.outputs.ATTEMPT_1_REGION }}"
+          echo "region=${{ steps.parse-regions.outputs.COMBO_1_REGION }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_1_REGION }}"
         elif [ "${{ steps.start-ec2-runner-2.outcome }}" == "success" ]; then
           echo "label=${{ steps.start-ec2-runner-2.outputs.label }}" >> $GITHUB_OUTPUT
           echo "ec2-instance-id=${{ steps.start-ec2-runner-2.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "region=${{ steps.setup-attempts.outputs.ATTEMPT_2_REGION }}" >> $GITHUB_OUTPUT
-          echo "Runner successfully started in ${{ steps.setup-attempts.outputs.ATTEMPT_2_REGION }}"
+          echo "region=${{ steps.parse-regions.outputs.COMBO_2_REGION }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_2_REGION }}"
         elif [ "${{ steps.start-ec2-runner-3.outcome }}" == "success" ]; then
           echo "label=${{ steps.start-ec2-runner-3.outputs.label }}" >> $GITHUB_OUTPUT
           echo "ec2-instance-id=${{ steps.start-ec2-runner-3.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "region=${{ steps.setup-attempts.outputs.ATTEMPT_3_REGION }}" >> $GITHUB_OUTPUT
-          echo "Runner successfully started in ${{ steps.setup-attempts.outputs.ATTEMPT_3_REGION }}"
+          echo "region=${{ steps.parse-regions.outputs.COMBO_3_REGION }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_3_REGION }}"
+        elif [ "${{ steps.start-ec2-runner-4.outcome }}" == "success" ]; then
+          echo "label=${{ steps.start-ec2-runner-4.outputs.label }}" >> $GITHUB_OUTPUT
+          echo "ec2-instance-id=${{ steps.start-ec2-runner-4.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          echo "region=${{ steps.parse-regions.outputs.COMBO_4_REGION }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_4_REGION }}"
+        elif [ "${{ steps.start-ec2-runner-5.outcome }}" == "success" ]; then
+          echo "label=${{ steps.start-ec2-runner-5.outputs.label }}" >> $GITHUB_OUTPUT
+          echo "ec2-instance-id=${{ steps.start-ec2-runner-5.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          echo "region=${{ steps.parse-regions.outputs.COMBO_5_REGION }}" >> $GITHUB_OUTPUT
+          echo "Runner successfully started in ${{ steps.parse-regions.outputs.COMBO_5_REGION }}"
         else
           echo "All runner attempts failed. Please check AWS capacity availability across regions."
           exit 1

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -192,6 +192,7 @@ runs:
     - name: Start EC2 runner
       id: start-ec2-runner
       uses: yonch/ec2-github-runner@feature/multiple-az
+      continue-on-error: true
       with:
         mode: start
         startup-quiet-period-seconds: 10
@@ -220,10 +221,10 @@ runs:
       shell: bash
       run: |
         # Pass through the runner outputs
-        if [ -n "${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" ]; then
-          echo "label=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
-          echo "ec2-instance-id=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "region=${{ steps.start-ec2-runner.outputs.region }}" >> $GITHUB_OUTPUT
+        echo "label=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
+        echo "ec2-instance-id=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+        echo "region=${{ steps.start-ec2-runner.outputs.region }}" >> $GITHUB_OUTPUT
+        if [ -n "${{ steps.start-ec2-runner.outputs.label }}" ]; then
           echo "Runner successfully started in region: ${{ steps.start-ec2-runner.outputs.region }}"
         else
           echo "All runner attempts failed. Please check AWS capacity availability across regions."

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -191,7 +191,7 @@ runs:
     # Start EC2 runner with availability-zones-config
     - name: Start EC2 runner
       id: start-ec2-runner
-      uses: yonch/ec2-github-runner@7a4aa1ca6bf1a5c20e2695db772465e3fced63a2
+      uses: yonch/ec2-github-runner@feature/multiple-az
       with:
         mode: start
         startup-quiet-period-seconds: 10

--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -50,6 +50,10 @@ inputs:
           "security-group-id": "sg-0c0fb801b9d5afb42",
           "subnets": ["subnet-0f218a8f807b24b43", "subnet-03760fcc21de05dcf", "subnet-07f33ad4e85154757", "subnet-06a59c6d0f0ae0acf", "subnet-01411d66f3c3b03ab", "subnet-0aacbbfdb4730c3ae"]
         },
+        "us-east-2": {
+          "security-group-id": "sg-0da5b1b4abff16f01",
+          "subnets": ["subnet-057997a168b11832e", "subnet-04231f222c6778d25", "subnet-085a10d33b29607cd"]
+        },
         "us-west-2": {
           "security-group-id": "sg-065a194f058366e19",
           "subnets": ["subnet-03312d0e183ac6bd2", "subnet-0504fa9cacd9bece7", "subnet-07669de00a10cb45a", "subnet-027770cb161c110b2"]
@@ -67,12 +71,14 @@ inputs:
         "ubuntu-22.04": {
           "us-east-1": "ami-0f9de6e2d2f067fca",
           "us-west-2": "ami-03f8acd418785369b",
-          "eu-west-1": "ami-0f0c3baa60262d5b9"
+          "eu-west-1": "ami-0f0c3baa60262d5b9",
+          "us-east-2": "ami-0c3b809fcf2445b6a"
         },
         "ubuntu-24.04": {
           "us-east-1": "ami-084568db4383264d4",
           "us-west-2": "ami-075686beab831bb7f",
-          "eu-west-1": "ami-0df368112825f8d8f"
+          "eu-west-1": "ami-0df368112825f8d8f",
+          "us-east-2": "ami-04f167a56786e4b09"
         }
       }
 

--- a/.github/actions/aws-runner/cleanup/action.yml
+++ b/.github/actions/aws-runner/cleanup/action.yml
@@ -30,7 +30,7 @@ runs:
         role-session-name: github-runner-session
 
     - name: Stop EC2 runner
-      uses: devin-purple/ec2-github-runner@97328aea29a7b1da7f840fd9434b3046dfcc07a9
+      uses: yonch/ec2-github-runner@feature/multiple-az
       with:
         mode: stop
         github-token: ${{ inputs.github-token }}

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,4 +1,4 @@
-name: demo
+name: benchmark
 on: 
   workflow_dispatch:  # Manual trigger for testing
     inputs:

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -72,6 +72,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(needs.setup-runner.outputs.timeout-minutes) }}
     outputs:
       uuid-prefix: ${{ steps.generate-uuid.outputs.uuid }}
+      time-diff: ${{ steps.calculate-time-diff.outputs.time-diff }}
     env:
       RELEASE_NAME: otel-demo
       COLLECTOR_RELEASE_NAME: collector
@@ -250,12 +251,15 @@ jobs:
             --set resources.requests.cpu=1000m \
             --set resources.limits.memory=1000Mi \
             --wait
-
+          
       - name: (collector) Wait for Collector Pods to be Ready
         run: |
           kubectl wait --for=condition=Ready pods --timeout=60s -l app.kubernetes.io/name=collector || WAIT_STATUS=$?
           echo "Wait exit status: $WAIT_STATUS"
-          
+
+          # Record timestamp when collector is fully ready
+          COLLECTOR_START_TIME=$(date +%s)
+
           # Always describe pods, regardless of wait result
           echo "Describing collector pods:"
           kubectl describe pods -l app.kubernetes.io/name=collector
@@ -265,7 +269,10 @@ jobs:
             echo "ERROR: Collector pods are not ready after timeout"
             exit 1
           fi
-
+          
+          # Output the timestamp when collector is fully ready
+          echo "COLLECTOR_START_TIME=${COLLECTOR_START_TIME}" >> $GITHUB_ENV
+          echo "Collector fully ready at timestamp: ${COLLECTOR_START_TIME}"
       - name: (collector) Show Collector Pod Status
         run: |
           kubectl get pods -l app.kubernetes.io/name=collector
@@ -274,9 +281,24 @@ jobs:
       #### Start load generator
 
       - name: (workload) Start Load Generator
+        id: calculate-time-diff
         run: |
           helm upgrade $RELEASE_NAME open-telemetry/opentelemetry-demo -f deploy/opentelemetry-demo/values.yaml \
-            --set components.load-generator.enabled=true --wait
+            --set components.load-generator.enabled=true
+          
+          # Wait for load generator pods to be specifically in Ready state
+          echo "Waiting for load generator pods to be ready..."
+          kubectl wait --for=condition=Ready pods -l app.kubernetes.io/component=load-generator --timeout=60s || true
+          
+          # Record timestamp when load generator is fully ready
+          LOAD_GEN_START_TIME=$(date +%s)
+          
+          # Calculate the time difference between collector and load generator start
+          TIME_DIFF=$((LOAD_GEN_START_TIME - COLLECTOR_START_TIME))
+          echo "time-diff=${TIME_DIFF}" >> $GITHUB_OUTPUT
+          echo "TIME_DIFF=${TIME_DIFF}" >> $GITHUB_ENV
+          echo "Load generator fully ready at timestamp: ${LOAD_GEN_START_TIME}"
+          echo "Time difference between collector and load generator ready: ${TIME_DIFF} seconds"
 
       - name: (workload) Describe Load Generator Deployment
         run: |
@@ -570,6 +592,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       STEADY_STATE_MINUTES: ${{ inputs.steady-state-minutes || '1' }}
+      TIME_DIFF: ${{ needs.run-workload.outputs.time-diff || '0' }}
     container:
       image: rocker/tidyverse:latest
     steps:
@@ -642,11 +665,20 @@ jobs:
 
       - name: Generate LLC Misses Plots
         run: |
-          # Generate LLC misses plots
-          # run these starting at 20 seconds and starting at 90 seconds
+          # The collector is ready TIME_DIFF seconds before the load generator is ready
+          TIME_DIFF=${TIME_DIFF:-0}
+          
+          # Calculate adjusted start times relative to when collector is ready
+          START_TIME_1=$((20 + TIME_DIFF))
+          START_TIME_2=$((180 + TIME_DIFF))
+          
+          echo "Using adjusted start times: $START_TIME_1 and $START_TIME_2 seconds after collector is ready"
+          echo "Time difference between collector and load generator ready states: ${TIME_DIFF} seconds"
+          
+          # Generate LLC misses plots with the adjusted start times
           for i in 0.3 0.5 1 3 10; do
-            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 20 $i visualization_results/llc_misses_20sec_$i || true
-            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 180 $i visualization_results/llc_misses_180sec_$i || true
+            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet $START_TIME_1 $i visualization_results/llc_misses_20sec_$i || true
+            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet $START_TIME_2 $i visualization_results/llc_misses_180sec_$i || true
           done
 
           # Check output
@@ -672,14 +704,18 @@ jobs:
 
       - name: Generate CPI by LLC Misses Plots
         run: |
-          # Calculate the time window based on steady state minutes
-          # Start: Always 205 seconds (5 seconds after 200s mark)
-          # End: End 5 seconds before the steady state ends (200s + STEADY_STATE_MINUTES*60 - 5s)
-          START_TIME=205
+          # Calculate the time window based on steady state minutes and the time difference between
+          # when collector is ready and when load generator is ready
+          TIME_DIFF=${TIME_DIFF:-0}
+          
+          # Start: 200 seconds after load generator is ready (which is 200+TIME_DIFF seconds after collector is ready)
+          # End: End 5 seconds before the steady state ends
+          START_TIME=$((205 + TIME_DIFF))
           STEADY_STATE_SECONDS=$((${STEADY_STATE_MINUTES} * 60))
-          END_TIME=$((200 + STEADY_STATE_SECONDS - 5))
+          END_TIME=$((200 + STEADY_STATE_SECONDS - 5 + TIME_DIFF))
           
           echo "Using time window: $START_TIME - $END_TIME seconds (steady state: ${STEADY_STATE_MINUTES} min)"
+          echo "Time difference between collector and load generator ready states: ${TIME_DIFF} seconds"
           
           # Generate CPI by LLC misses plots with time window parameters
           Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_75 23 75 $START_TIME $END_TIME

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -718,9 +718,7 @@ jobs:
           echo "Time difference between collector and load generator ready states: ${TIME_DIFF} seconds"
           
           # Generate CPI by LLC misses plots with time window parameters
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_75 23 75 $START_TIME $END_TIME
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_50 23 50 $START_TIME $END_TIME
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_25 23 25 $START_TIME $END_TIME
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_75 23 $START_TIME $END_TIME
 
       - name: Upload Visualization Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -5,7 +5,12 @@ on:
       instance-type:
         description: 'EC2 instance type to use'
         required: false
-        default: 'c5.9xlarge,c6i.16xlarge'
+        default: 'c5.9xlarge'
+        type: string
+      image-type:
+        description: 'Image type to use (ubuntu-22.04 or ubuntu-24.04)'
+        required: false
+        default: 'ubuntu-22.04'
         type: string
       pidstat-period:
         description: 'Collection frequency for pidstat in seconds'
@@ -31,6 +36,7 @@ jobs:
     outputs:
       runner-label: ${{ steps.start-runner.outputs.runner-label }}
       ec2-instance-id: ${{ steps.start-runner.outputs.ec2-instance-id }}
+      region: ${{ steps.start-runner.outputs.region }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,12 +47,9 @@ jobs:
         with:
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          subnet-id: ${{ secrets.AWS_SUBNET_ID }}
-          security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
           iam-role-name: github-actions-runner          
-          instance-type: ${{ inputs.instance-type || 'c5.9xlarge,c7i.12xlarge,m7i.12xlarge,c6i.16xlarge' }}
-          aws-image-id: 'ami-0884d2865dbe9de4b'  # Ubuntu 22.04 LTS in us-east-2
+          instance-type: ${{ inputs.instance-type || 'c5.9xlarge' }}
+          image-type: ${{ inputs.image-type || 'ubuntu-22.04' }}
           volume-size: '40'
 
   run-workload:
@@ -646,4 +649,4 @@ jobs:
           ec2-instance-id: ${{ needs.setup-runner.outputs.ec2-instance-id }}
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }} 
+          aws-region: ${{ needs.setup-runner.outputs.region || secrets.AWS_REGION }} 

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -255,6 +255,18 @@ jobs:
           kubectl get pods -l app.kubernetes.io/name=collector
           kubectl logs -l app.kubernetes.io/name=collector -c collector --tail=10
 
+      #### Start load generator
+
+      - name: (workload) Start Load Generator
+        run: |
+          helm upgrade $RELEASE_NAME open-telemetry/opentelemetry-demo -f deploy/opentelemetry-demo/values.yaml \
+            --set components.load-generator.enabled=true --wait
+
+      - name: (workload) Describe Load Generator Deployment
+        run: |
+          kubectl describe deployment load-generator
+
+
       #### Start PIDs stat collection
 
       - name: (metrics) Start PIDs stat collection
@@ -290,18 +302,6 @@ jobs:
           echo "Memory metrics PID: ${MEMORY_PIDSTAT_PID}"
           echo "CPU metrics file: ${CPU_METRICS_FILE}"
           echo "Memory metrics file: ${MEMORY_METRICS_FILE}"
-
-      #### Start load generator
-
-      - name: (workload) Start Load Generator
-        run: |
-          helm upgrade $RELEASE_NAME open-telemetry/opentelemetry-demo -f deploy/opentelemetry-demo/values.yaml \
-            --set components.load-generator.enabled=true --wait
-
-      - name: (workload) Describe Load Generator Deployment
-        run: |
-          kubectl describe deployment load-generator
-
 
       - name: (metrics) Record system performance with perf
         run: |

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -255,18 +255,6 @@ jobs:
           kubectl get pods -l app.kubernetes.io/name=collector
           kubectl logs -l app.kubernetes.io/name=collector -c collector --tail=10
 
-      #### Start load generator
-
-      - name: (workload) Start Load Generator
-        run: |
-          helm upgrade $RELEASE_NAME open-telemetry/opentelemetry-demo -f deploy/opentelemetry-demo/values.yaml \
-            --set components.load-generator.enabled=true --wait
-
-      - name: (workload) Describe Load Generator Deployment
-        run: |
-          kubectl describe deployment load-generator
-
-
       #### Start PIDs stat collection
 
       - name: (metrics) Start PIDs stat collection
@@ -302,6 +290,18 @@ jobs:
           echo "Memory metrics PID: ${MEMORY_PIDSTAT_PID}"
           echo "CPU metrics file: ${CPU_METRICS_FILE}"
           echo "Memory metrics file: ${MEMORY_METRICS_FILE}"
+
+      #### Start load generator
+
+      - name: (workload) Start Load Generator
+        run: |
+          helm upgrade $RELEASE_NAME open-telemetry/opentelemetry-demo -f deploy/opentelemetry-demo/values.yaml \
+            --set components.load-generator.enabled=true --wait
+
+      - name: (workload) Describe Load Generator Deployment
+        run: |
+          kubectl describe deployment load-generator
+
 
       - name: (metrics) Record system performance with perf
         run: |

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -309,8 +309,11 @@ jobs:
           # Create directory for perf data
           mkdir -p /tmp/perf_data
           
-          echo "Starting perf record for 240 seconds at 19Hz frequency..."
-          perf record -a -g -F 19 --call-graph dwarf -o /tmp/perf_data/perf.data sleep 240
+          echo "Ramping up load generator without perf record..."
+          sleep 200
+
+          echo "Starting perf record for 40 seconds at 19Hz frequency..."
+          perf record -a -g -F 19 --call-graph dwarf -o /tmp/perf_data/perf.data sleep 40
           
           # Create directory for perf results
           mkdir -p perf_results

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -642,9 +642,9 @@ jobs:
       - name: Generate CPI by LLC Misses Plots
         run: |
           # Generate CPI by LLC misses plots
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 23 75 visualization_results/cpi_by_llc_misses_75
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 23 50 visualization_results/cpi_by_llc_misses_50
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 23 25 visualization_results/cpi_by_llc_misses_25
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_75 23 75 
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_50 23 50
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_25 23 25
 
       - name: Upload Visualization Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -599,12 +599,12 @@ jobs:
       - name: Generate LLC Misses Plots
         run: |
           # Generate LLC misses plots
-          Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 90 0.3 visualization_results/llc_misses_0.3sec
-          Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 90 0.5 visualization_results/llc_misses_0.5sec
-          Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 90 1 visualization_results/llc_misses_1sec
-          Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 90 3 visualization_results/llc_misses_3sec
-          Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 90 10 visualization_results/llc_misses_10sec
-          
+          # run these starting at 20 seconds and starting at 90 seconds
+          for i in 0.3 0.5 1 3 10; do
+            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 20 $i visualization_results/llc_misses_20sec_$i
+            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 90 $i visualization_results/llc_misses_90sec_$i
+          done
+
           # Check output
           ls -la visualization_results/
 

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -379,7 +379,7 @@ jobs:
 
       - name: (collector) Send SIGUSR1 to Collector
         run: |
-          kubectl exec -it -n default $(kubectl get pods -l app.kubernetes.io/name=collector -o name | cut -d/ -f2) -- /bin/sh -c "kill -USR1 $(pgrep -f 'collector')"
+          kubectl exec -n default $(kubectl get pods -l app.kubernetes.io/name=collector -o name | cut -d/ -f2) -- /bin/sh -c "kill -USR1 1"
           sleep 3
 
       - name: (collector) Uninstall Collector Helm Chart

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -233,6 +233,7 @@ jobs:
             --set storage.s3.auth.secretKey="${AWS_SECRET_ACCESS_KEY}" \
             --set resources.limits.cpu=1000m \
             --set resources.requests.cpu=1000m \
+            --set resources.limits.memory=1000Mi \
             --wait
 
       - name: (collector) Wait for Collector Pods to be Ready

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -602,8 +602,8 @@ jobs:
           # Generate LLC misses plots
           # run these starting at 20 seconds and starting at 90 seconds
           for i in 0.3 0.5 1 3 10; do
-            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 20 $i visualization_results/llc_misses_20sec_$i
-            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 180 $i visualization_results/llc_misses_180sec_$i
+            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 20 $i visualization_results/llc_misses_20sec_$i || true
+            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 180 $i visualization_results/llc_misses_180sec_$i || true
           done
 
           # Check output

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -377,6 +377,11 @@ jobs:
           path: system_metrics/
           retention-days: 28
 
+      - name: (collector) Send SIGUSR1 to Collector
+        run: |
+          kubectl exec -it -n default $(kubectl get pods -l app.kubernetes.io/name=collector -o name | cut -d/ -f2) -- /bin/sh -c "kill -USR1 $(pgrep -f 'collector')"
+          sleep 3
+
       - name: (collector) Uninstall Collector Helm Chart
         run: |
           # see the logs while uninstalling

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -567,6 +567,8 @@ jobs:
     name: Generate Performance Visualizations
     needs: [run-workload]
     runs-on: ubuntu-latest
+    env:
+      STEADY_STATE_MINUTES: ${{ inputs.steady-state-minutes || '1' }}
     container:
       image: rocker/tidyverse:latest
     steps:
@@ -669,10 +671,19 @@ jobs:
 
       - name: Generate CPI by LLC Misses Plots
         run: |
-          # Generate CPI by LLC misses plots
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_75 23 75 
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_50 23 50
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_25 23 25
+          # Calculate the time window based on steady state minutes
+          # Start: Always 205 seconds (5 seconds after 200s mark)
+          # End: End 5 seconds before the steady state ends (200s + STEADY_STATE_MINUTES*60 - 5s)
+          START_TIME=205
+          STEADY_STATE_SECONDS=$((${STEADY_STATE_MINUTES} * 60))
+          END_TIME=$((200 + STEADY_STATE_SECONDS - 5))
+          
+          echo "Using time window: $START_TIME - $END_TIME seconds (steady state: ${STEADY_STATE_MINUTES} min)"
+          
+          # Generate CPI by LLC misses plots with time window parameters
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_75 23 75 $START_TIME $END_TIME
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_50 23 50 $START_TIME $END_TIME
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_25 23 25 $START_TIME $END_TIME
 
       - name: Upload Visualization Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -713,12 +713,26 @@ jobs:
           START_TIME=$((205 + TIME_DIFF))
           STEADY_STATE_SECONDS=$((${STEADY_STATE_MINUTES} * 60))
           END_TIME=$((200 + STEADY_STATE_SECONDS - 5 + TIME_DIFF))
+
+          # Calculate an alternative end time capped at 180 seconds from start
+          END_TIME_CAPPED=$((START_TIME + 180))
+
+          # Use the earlier of the two end times for the main plot
+          if [ "$END_TIME_CAPPED" -lt "$END_TIME" ]; then
+            echo "Using capped end time (180s from start): $START_TIME - $END_TIME_CAPPED seconds (steady state: ${STEADY_STATE_MINUTES} min)"
+            echo "Time difference between collector and load generator ready states: ${TIME_DIFF} seconds"
+            
+            # Generate an additional plot with the original end time
+            Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_capped 23 $START_TIME $END_TIME_CAPPED
+          else
+            echo "No need to cap the length: using steady state end time"
+          fi
           
           echo "Using time window: $START_TIME - $END_TIME seconds (steady state: ${STEADY_STATE_MINUTES} min)"
           echo "Time difference between collector and load generator ready states: ${TIME_DIFF} seconds"
           
           # Generate CPI by LLC misses plots with time window parameters
-          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses_75 23 $START_TIME $END_TIME
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 visualization_results/cpi_by_llc_misses 23 $START_TIME $END_TIME || true
 
       - name: Upload Visualization Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -627,6 +627,13 @@ jobs:
           # Check output
           ls -la visualization_results/
 
+      - name: Generate CPI by LLC Misses Plots
+        run: |
+          # Generate CPI by LLC misses plots
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 23 75 visualization_results/cpi_by_llc_misses_75
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 23 50 visualization_results/cpi_by_llc_misses_50
+          Rscript scripts/plot_cpi_by_llc_misses.R collector_data/collector-parquet.parquet 100000 23 25 visualization_results/cpi_by_llc_misses_25
+
       - name: Upload Visualization Results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -42,7 +42,7 @@ jobs:
       runner-label: ${{ steps.start-runner.outputs.runner-label }}
       ec2-instance-id: ${{ steps.start-runner.outputs.ec2-instance-id }}
       region: ${{ steps.start-runner.outputs.region }}
-      timeout-minutes: ${{ steps.calculate-timeout.outputs.timeout }}
+      timeout-minutes: ${{ steps.calculate-timeout.outputs.timeout-minutes }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
         run: |
           STEADY_STATE_MINUTES=${{ inputs.steady-state-minutes || '1' }}
           TIMEOUT_MINUTES=$((15 + STEADY_STATE_MINUTES))
-          echo "timeout=$TIMEOUT_MINUTES" >> $GITHUB_OUTPUT
+          echo "timeout-minutes=$TIMEOUT_MINUTES" >> $GITHUB_OUTPUT
           echo "Calculated timeout: $TIMEOUT_MINUTES minutes"
         
       - name: Start AWS Runner
@@ -69,7 +69,7 @@ jobs:
   run-workload:
     needs: [setup-runner]
     runs-on: ${{ needs.setup-runner.outputs.runner-label }}
-    timeout-minutes: ${{ needs.setup-runner.outputs.timeout-minutes }}
+    timeout-minutes: ${{ fromJSON(needs.setup-runner.outputs.timeout-minutes) }}
     outputs:
       uuid-prefix: ${{ steps.generate-uuid.outputs.uuid }}
     env:
@@ -483,6 +483,7 @@ jobs:
     name: Generate Flamegraphs
     needs: [setup-runner, run-workload]
     runs-on: ${{ needs.setup-runner.outputs.runner-label }}
+    timeout-minutes: 10
     env:
       HOME: /root
     steps:

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -303,13 +303,14 @@ jobs:
           echo "CPU metrics file: ${CPU_METRICS_FILE}"
           echo "Memory metrics file: ${MEMORY_METRICS_FILE}"
 
+      #### Main run time
       - name: (metrics) Record system performance with perf
         run: |
           # Create directory for perf data
           mkdir -p /tmp/perf_data
           
-          echo "Starting perf record for 120 seconds at 19Hz frequency..."
-          perf record -a -g -F 19 --call-graph dwarf -o /tmp/perf_data/perf.data sleep 120
+          echo "Starting perf record for 240 seconds at 19Hz frequency..."
+          perf record -a -g -F 19 --call-graph dwarf -o /tmp/perf_data/perf.data sleep 240
           
           # Create directory for perf results
           mkdir -p perf_results
@@ -602,7 +603,7 @@ jobs:
           # run these starting at 20 seconds and starting at 90 seconds
           for i in 0.3 0.5 1 3 10; do
             Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 20 $i visualization_results/llc_misses_20sec_$i
-            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 90 $i visualization_results/llc_misses_90sec_$i
+            Rscript scripts/plot_llc_misses.R collector_data/collector-parquet.parquet 180 $i visualization_results/llc_misses_180sec_$i
           done
 
           # Check output

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -136,7 +136,18 @@ jobs:
             echo "Still waiting for kube-system pod registration..."
           done
           echo "Kube-system pod(s) registered, waiting for Ready status..."
-          kubectl wait --namespace kube-system --for=condition=Ready pods --all --timeout=300s
+          for i in {1..5}; do
+            echo "Attempt $i of 5: Waiting for kube-system pods (60s timeout)..."
+            if kubectl wait --namespace kube-system --for=condition=Ready pods --all --timeout=60s; then
+              echo "All kube-system pods are ready!"
+              break
+            elif [ $i -eq 5 ]; then
+              echo "Final attempt failed. Exiting with error."
+              exit 1
+            else
+              echo "Attempt $i failed. Retrying..."
+            fi
+          done
 
       #### Install OpenTelemetry Demo
       - name: (workload) Install OpenTelemetry Demo

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         default: '1'
         type: string
+      steady-state-minutes:
+        description: 'How long to run the steady-state workload in minutes'
+        required: false
+        default: '1'
+        type: string
   push:
     branches:
       - main
@@ -37,9 +42,18 @@ jobs:
       runner-label: ${{ steps.start-runner.outputs.runner-label }}
       ec2-instance-id: ${{ steps.start-runner.outputs.ec2-instance-id }}
       region: ${{ steps.start-runner.outputs.region }}
+      timeout-minutes: ${{ steps.calculate-timeout.outputs.timeout }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        
+      - name: Calculate timeout
+        id: calculate-timeout
+        run: |
+          STEADY_STATE_MINUTES=${{ inputs.steady-state-minutes || '1' }}
+          TIMEOUT_MINUTES=$((15 + STEADY_STATE_MINUTES))
+          echo "timeout=$TIMEOUT_MINUTES" >> $GITHUB_OUTPUT
+          echo "Calculated timeout: $TIMEOUT_MINUTES minutes"
         
       - name: Start AWS Runner
         id: start-runner
@@ -55,7 +69,7 @@ jobs:
   run-workload:
     needs: [setup-runner]
     runs-on: ${{ needs.setup-runner.outputs.runner-label }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ needs.setup-runner.outputs.timeout-minutes }}
     outputs:
       uuid-prefix: ${{ steps.generate-uuid.outputs.uuid }}
     env:
@@ -66,6 +80,7 @@ jobs:
       HOME: /root
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml
       PIDSTAT_PERIOD: ${{ inputs.pidstat-period || '1' }}
+      STEADY_STATE_MINUTES: ${{ inputs.steady-state-minutes || '1' }}
     steps:
       - name: Create HOME directory
         run: |
@@ -313,8 +328,20 @@ jobs:
           echo "Ramping up load generator without perf record..."
           sleep 200
 
-          echo "Starting perf record for 40 seconds at 19Hz frequency..."
-          perf record -a -g -F 19 --call-graph dwarf -o /tmp/perf_data/perf.data sleep 40
+          STEADY_STATE_MINUTES=${STEADY_STATE_MINUTES}
+          PERF_RECORD_SECONDS=60
+          
+          # Calculate the sleep duration (all minutes except the last one)
+          if [[ $STEADY_STATE_MINUTES -gt 1 ]]; then
+            SLEEP_MINUTES=$((STEADY_STATE_MINUTES - 1))
+            SLEEP_SECONDS=$((SLEEP_MINUTES * 60))
+            
+            echo "Sleeping for $SLEEP_MINUTES minutes ($SLEEP_SECONDS seconds) before perf recording..."
+            sleep $SLEEP_SECONDS
+          fi
+          
+          echo "Starting perf record for $PERF_RECORD_SECONDS seconds at 19Hz frequency..."
+          perf record -a -g -F 19 --call-graph dwarf -o /tmp/perf_data/perf.data sleep $PERF_RECORD_SECONDS
           
           # Create directory for perf results
           mkdir -p perf_results

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -425,6 +425,15 @@ jobs:
           name: collector-parquet-results
           path: /tmp/collector-parquet.parquet
           retention-days: 28
+          
+      - name: (status) Print Events
+        run: | 
+          kubectl get events
+
+      - name: (status) Print Pod Status
+        run: | 
+          kubectl get pods -n default
+
 
   generate-flamegraphs:
     name: Generate Flamegraphs

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -377,10 +377,14 @@ jobs:
           path: system_metrics/
           retention-days: 28
 
-      - name: (collector) Send SIGUSR1 to Collector
+      - name: (collector) Send SIGINT to Collector
         run: |
-          kubectl exec -n default $(kubectl get pods -l app.kubernetes.io/name=collector -o name | cut -d/ -f2) -- /bin/sh -c "kill -USR1 1"
-          sleep 3
+          kubectl exec -n default $(kubectl get pods -l app.kubernetes.io/name=collector -o name | cut -d/ -f2) -- /bin/sh -c "kill -INT 1"
+          sleep 10
+
+      - name: (collector) Print Collector Logs
+        run: |
+          kubectl logs -l app.kubernetes.io/name=collector || true
 
       - name: (collector) Uninstall Collector Helm Chart
         run: |

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -102,7 +102,9 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
-    replicas: 12
+    resources:
+      limits:
+        memory: 650Mi
     
   quote:
     useDefault:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -23,28 +23,28 @@ components:
 
   accounting:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
   ad:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
   cart:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
   checkout:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
@@ -64,26 +64,35 @@ components:
 
   email:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
   fraud-detection:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
   frontend:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
   frontend-proxy:
+    useDefault:
+      env: false
+    envOverrides:
+      - name: OTEL_COLLECTOR_HOST
+        value: ""
+      - name: OTEL_COLLECTOR_PORT_GRPC
+        value: ""
+      - name: OTEL_COLLECTOR_PORT_HTTP
+        value: ""
     replicas: 6
     resources:
       limits:
@@ -91,21 +100,21 @@ components:
 
   image-provider:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
   payment:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
   product-catalog:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
@@ -115,14 +124,14 @@ components:
     
   quote:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
   recommendation:
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
@@ -136,7 +145,7 @@ components:
     enabled: false
     replicas: 1 # only one replica for load-generator, it spawns multiple processes
     useDefault:
-      env: true
+      env: false
     envOverrides:
       - name: LOCUST_CSV
         value: "/tmp/locust_results/stats"

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -1,5 +1,5 @@
 default:
-  replicas: 9 # multiple replicas for most services
+  replicas: 3 # multiple replicas for most services
 
 opentelemetry-collector:
   enabled: false

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -77,7 +77,7 @@ components:
         value: "" # Disable
 
   frontend:
-    replicas: 6
+    replicas: 9
     useDefault:
       env: false
     envOverrides:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -84,6 +84,7 @@ components:
         value: "" # Disable
 
   frontend-proxy:
+    replicas: 6
     resources:
       limits:
         memory: 650Mi

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -58,6 +58,9 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
+    resources:
+      limits:
+        memory: 200Mi
 
   email:
     useDefault:
@@ -123,12 +126,10 @@ components:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
 
-  # shipping:
-  #   useDefault:
-  #     env: true
-  #   envOverrides:
-  #     - name: OTEL_EXPORTER_OTLP_ENDPOINT
-  #       value: "" # Disable
+  shipping:
+    resources:
+      limits:
+        memory: 200Mi
 
   load-generator:
     enabled: false

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -48,6 +48,9 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
+    resources:
+      limits:
+        memory: 650Mi
 
   currency:
     useDefault:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -270,9 +270,9 @@ components:
             class WebsiteUser(FastHttpUser):
                 wait_time = between(1, 10)
 
-                # @task(1)
-                # def index(self):
-                #     self.client.get("/")
+                @task(1)
+                def index(self):
+                    self.client.get("/")
 
                 @task(10)
                 def browse_product(self):

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -77,6 +77,7 @@ components:
         value: "" # Disable
 
   frontend:
+    replicas: 1
     useDefault:
       env: false
     envOverrides:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -154,9 +154,9 @@ components:
       - name: LOCUST_HEADLESS
         value: "true"
       - name: LOCUST_USERS
-        value: "7200"
+        value: "10800"
       - name: LOCUST_SPAWN_RATE
-        value: "72"
+        value: "108"
       - name: LOCUST_BROWSER_TRAFFIC_ENABLED
         value: "false"
       - name: LOCUST_PROCESSES

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -77,7 +77,7 @@ components:
         value: "" # Disable
 
   frontend:
-    replicas: 9
+    replicas: 12
     useDefault:
       env: false
     envOverrides:
@@ -154,9 +154,9 @@ components:
       - name: LOCUST_HEADLESS
         value: "true"
       - name: LOCUST_USERS
-        value: "10800"
+        value: "13000"
       - name: LOCUST_SPAWN_RATE
-        value: "108"
+        value: "130"
       - name: LOCUST_BROWSER_TRAFFIC_ENABLED
         value: "false"
       - name: LOCUST_PROCESSES

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -60,7 +60,7 @@ components:
     #     value: "" # Disable
     resources:
       limits:
-        memory: 200Mi
+        memory: 400Mi
 
   email:
     useDefault:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -157,9 +157,9 @@ components:
       - name: LOCUST_HEADLESS
         value: "true"
       - name: LOCUST_USERS
-        value: "13000"
+        value: "11000"
       - name: LOCUST_SPAWN_RATE
-        value: "65"
+        value: "55"
       - name: LOCUST_BROWSER_TRAFFIC_ENABLED
         value: "false"
       - name: LOCUST_PROCESSES

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -2,7 +2,7 @@ default:
   replicas: 3 # multiple replicas for most services
 
 opentelemetry-collector:
-  enabled: false
+  enabled: true
 
 opensearch:
   enabled: false
@@ -53,11 +53,11 @@ components:
         memory: 650Mi
 
   currency:
-    useDefault:
-      env: true
-    envOverrides:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: "" # Disable
+    # useDefault:
+    #   env: true
+    # envOverrides:
+    #   - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    #     value: "" # Disable
     resources:
       limits:
         memory: 200Mi

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -68,6 +68,9 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
+    resources:
+      limits:
+        memory: 200Mi
 
   fraud-detection:
     useDefault:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -286,18 +286,18 @@ components:
                     }
                     self.client.get("/api/recommendations", params=params)
 
-                # @task(3)
+                @task(3)
                 def get_ads(self):
                     params = {
                         "contextKeys": [random.choice(categories)],
                     }
                     self.client.get("/api/data/", params=params)
 
-                # @task(3)
+                @task(3)
                 def view_cart(self):
                     self.client.get("/api/cart")
 
-                # @task(2)
+                @task(2)
                 def add_to_cart(self, user=""):
                     if user == "":
                         user = str(uuid.uuid1())
@@ -321,7 +321,7 @@ components:
                     checkout_person["userId"] = user
                     self.client.post("/api/checkout", json=checkout_person)
 
-                # @task(1)
+                @task(1)
                 def checkout_multi(self):
                     # checkout call which adds 2-4 different items to cart before checkout
                     user = str(uuid.uuid1())
@@ -331,7 +331,7 @@ components:
                     checkout_person["userId"] = user
                     self.client.post("/api/checkout", json=checkout_person)
 
-                # @task(5)
+                @task(5)
                 def flood_home(self):
                     for _ in range(0, get_flagd_value("loadGeneratorFloodHomepage")):
                         self.client.get("/")

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -78,13 +78,6 @@ components:
         value: "" # Disable
 
   frontend-proxy:
-    useDefault:
-      env: true
-    envOverrides:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: "" # Disable
-      - name: OTEL_COLLECTOR_HOST
-        value: ""
     resources:
       limits:
         memory: 650Mi

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -104,6 +104,7 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
+    replicas: 9
     
   quote:
     useDefault:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -80,7 +80,7 @@ components:
         value: "" # Disable
 
   frontend:
-    replicas: 12
+    replicas: 15
     useDefault:
       env: false
     envOverrides:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -104,7 +104,7 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
-    replicas: 9
+    replicas: 12
     
   quote:
     useDefault:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -354,7 +354,7 @@ components:
                     ctx = baggage.set_baggage("session.id", str(uuid.uuid4()))
                     ctx = baggage.set_baggage("synthetic_request", "true", context=ctx)
                     context.attach(ctx)
-                    self.index()
+                    # self.index()
 
 
             browser_traffic_enabled = os.environ.get("LOCUST_BROWSER_TRAFFIC_ENABLED", "").lower() in ("true", "yes", "on")

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -279,12 +279,12 @@ components:
                 def browse_product(self):
                     self.client.get("/api/products/" + random.choice(products), name="/api/products/[id]")
 
-                # @task(3)
-                # def get_recommendations(self):
-                #     params = {
-                #         "productIds": [random.choice(products)],
-                #     }
-                #     self.client.get("/api/recommendations", params=params)
+                @task(3)
+                def get_recommendations(self):
+                    params = {
+                        "productIds": [random.choice(products)],
+                    }
+                    self.client.get("/api/recommendations", params=params)
 
                 # @task(3)
                 # def get_ads(self):

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -159,7 +159,7 @@ components:
       - name: LOCUST_USERS
         value: "13000"
       - name: LOCUST_SPAWN_RATE
-        value: "130"
+        value: "65"
       - name: LOCUST_BROWSER_TRAFFIC_ENABLED
         value: "false"
       - name: LOCUST_PROCESSES

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -83,6 +83,11 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
+      - name: OTEL_COLLECTOR_HOST
+        value: ""
+    resources:
+      limits:
+        memory: 650Mi
 
   image-provider:
     useDefault:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -287,54 +287,54 @@ components:
                     self.client.get("/api/recommendations", params=params)
 
                 # @task(3)
-                # def get_ads(self):
-                #     params = {
-                #         "contextKeys": [random.choice(categories)],
-                #     }
-                #     self.client.get("/api/data/", params=params)
+                def get_ads(self):
+                    params = {
+                        "contextKeys": [random.choice(categories)],
+                    }
+                    self.client.get("/api/data/", params=params)
 
                 # @task(3)
-                # def view_cart(self):
-                #     self.client.get("/api/cart")
+                def view_cart(self):
+                    self.client.get("/api/cart")
 
                 # @task(2)
-                # def add_to_cart(self, user=""):
-                #     if user == "":
-                #         user = str(uuid.uuid1())
-                #     product = random.choice(products)
-                #     self.client.get("/api/products/" + product)
-                #     cart_item = {
-                #         "item": {
-                #             "productId": product,
-                #             "quantity": random.choice([1, 2, 3, 4, 5, 10]),
-                #         },
-                #         "userId": user,
-                #     }
-                #     self.client.post("/api/cart", json=cart_item)
+                def add_to_cart(self, user=""):
+                    if user == "":
+                        user = str(uuid.uuid1())
+                    product = random.choice(products)
+                    self.client.get("/api/products/" + product)
+                    cart_item = {
+                        "item": {
+                            "productId": product,
+                            "quantity": random.choice([1, 2, 3, 4, 5, 10]),
+                        },
+                        "userId": user,
+                    }
+                    self.client.post("/api/cart", json=cart_item)
+
+                @task(1)
+                def checkout(self):
+                    # checkout call with an item added to cart
+                    user = str(uuid.uuid1())
+                    self.add_to_cart(user=user)
+                    checkout_person = random.choice(people)
+                    checkout_person["userId"] = user
+                    self.client.post("/api/checkout", json=checkout_person)
 
                 # @task(1)
-                # def checkout(self):
-                #     # checkout call with an item added to cart
-                #     user = str(uuid.uuid1())
-                #     self.add_to_cart(user=user)
-                #     checkout_person = random.choice(people)
-                #     checkout_person["userId"] = user
-                #     self.client.post("/api/checkout", json=checkout_person)
-
-                # @task(1)
-                # def checkout_multi(self):
-                #     # checkout call which adds 2-4 different items to cart before checkout
-                #     user = str(uuid.uuid1())
-                #     for i in range(random.choice([2, 3, 4])):
-                #         self.add_to_cart(user=user)
-                #     checkout_person = random.choice(people)
-                #     checkout_person["userId"] = user
-                #     self.client.post("/api/checkout", json=checkout_person)
+                def checkout_multi(self):
+                    # checkout call which adds 2-4 different items to cart before checkout
+                    user = str(uuid.uuid1())
+                    for i in range(random.choice([2, 3, 4])):
+                        self.add_to_cart(user=user)
+                    checkout_person = random.choice(people)
+                    checkout_person["userId"] = user
+                    self.client.post("/api/checkout", json=checkout_person)
 
                 # @task(5)
-                # def flood_home(self):
-                #     for _ in range(0, get_flagd_value("loadGeneratorFloodHomepage")):
-                #         self.client.get("/")
+                def flood_home(self):
+                    for _ in range(0, get_flagd_value("loadGeneratorFloodHomepage")):
+                        self.client.get("/")
 
                 def on_start(self):
                     ctx = baggage.set_baggage("session.id", str(uuid.uuid4()))

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -77,7 +77,7 @@ components:
         value: "" # Disable
 
   frontend:
-    replicas: 1
+    replicas: 6
     useDefault:
       env: false
     envOverrides:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -278,12 +278,12 @@ components:
                 def browse_product(self):
                     self.client.get("/api/products/" + random.choice(products), name="/api/products/[id]")
 
-                # @task(3)
-                # def get_recommendations(self):
-                #     params = {
-                #         "productIds": [random.choice(products)],
-                #     }
-                #     self.client.get("/api/recommendations", params=params)
+                @task(3)
+                def get_recommendations(self):
+                    params = {
+                        "productIds": [random.choice(products)],
+                    }
+                    self.client.get("/api/recommendations", params=params)
 
                 # @task(3)
                 # def get_ads(self):

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -27,6 +27,9 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
+    resources:
+      limits:
+        memory: 200Mi
 
   ad:
     useDefault:
@@ -41,6 +44,9 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
+    resources:
+      limits:
+        memory: 650Mi
 
   checkout:
     useDefault:
@@ -70,7 +76,7 @@ components:
         value: "" # Disable
     resources:
       limits:
-        memory: 200Mi
+        memory: 300Mi
 
   fraud-detection:
     useDefault:
@@ -86,6 +92,9 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
+    resources:
+      limits:
+        memory: 500Mi
 
   frontend-proxy:
     useDefault:
@@ -140,6 +149,11 @@ components:
         value: "" # Disable
 
   shipping:
+    resources:
+      limits:
+        memory: 200Mi
+
+  valkey-cart:
     resources:
       limits:
         memory: 200Mi

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -86,13 +86,6 @@ components:
   frontend-proxy:
     useDefault:
       env: false
-    envOverrides:
-      - name: OTEL_COLLECTOR_HOST
-        value: ""
-      - name: OTEL_COLLECTOR_PORT_GRPC
-        value: ""
-      - name: OTEL_COLLECTOR_PORT_HTTP
-        value: ""
     replicas: 6
     resources:
       limits:
@@ -103,6 +96,10 @@ components:
       env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: "" # Disable
+      - name: OTEL_SERVICE_NAME
+        value: "localhost:4318" # Disable
+      - name: OTEL_COLLECTOR_HOST
         value: "" # Disable
 
   payment:
@@ -134,6 +131,8 @@ components:
       env: false
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: "" # Disable
+      - name: OTEL_SERVICE_NAME
         value: "" # Disable
 
   shipping:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -1,5 +1,5 @@
 default:
-  replicas: 6 # multiple replicas for most services
+  replicas: 9 # multiple replicas for most services
 
 opentelemetry-collector:
   enabled: false

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -64,9 +64,10 @@ components:
     # envOverrides:
     #   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     #     value: "" # Disable
+    replicas: 5
     resources:
       limits:
-        memory: 400Mi
+        memory: 600Mi
 
   email:
     useDefault:
@@ -74,9 +75,10 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "" # Disable
+    replicas: 6
     resources:
       limits:
-        memory: 300Mi
+        memory: 600Mi
 
   fraud-detection:
     useDefault:

--- a/deploy/opentelemetry-demo/values.yaml
+++ b/deploy/opentelemetry-demo/values.yaml
@@ -278,12 +278,12 @@ components:
                 def browse_product(self):
                     self.client.get("/api/products/" + random.choice(products), name="/api/products/[id]")
 
-                @task(3)
-                def get_recommendations(self):
-                    params = {
-                        "productIds": [random.choice(products)],
-                    }
-                    self.client.get("/api/recommendations", params=params)
+                # @task(3)
+                # def get_recommendations(self):
+                #     params = {
+                #         "productIds": [random.choice(products)],
+                #     }
+                #     self.client.get("/api/recommendations", params=params)
 
                 # @task(3)
                 # def get_ads(self):

--- a/scripts/plot_cpi_by_llc_misses.R
+++ b/scripts/plot_cpi_by_llc_misses.R
@@ -150,7 +150,7 @@ create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes
   
   # Create the faceted histogram plot
   p <- ggplot(plot_data, aes(x = cpi_capped, fill = llc_category)) +
-    geom_histogram(position = "identity", alpha = 0.7, bins = 30) +
+    geom_density(alpha = 0.7, adjust = 1.5) +
     facet_wrap(~ process_group, scales = "free_y", ncol = 3) +
     scale_fill_manual(values = c("#E41A1C", "#377EB8")) +
     labs(
@@ -159,7 +159,7 @@ create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes
                        start_time_seconds, "-", end_time_seconds, "s window, ",
                        instruction_threshold, " instructions, ", llc_percentile, "% LLC miss percentile)"),
       x = "Cycles Per Instruction (CPI)",
-      y = "Count",
+      y = "Density",
       fill = "LLC Miss Category"
     ) +
     theme_minimal() +

--- a/scripts/plot_cpi_by_llc_misses.R
+++ b/scripts/plot_cpi_by_llc_misses.R
@@ -1,0 +1,189 @@
+#!/usr/bin/env Rscript
+
+# Setup - load required libraries
+if (!requireNamespace("nanoparquet", quietly = TRUE)) {
+  install.packages("nanoparquet")
+}
+if (!requireNamespace("ggplot2", quietly = TRUE)) {
+  install.packages("ggplot2")
+}
+if (!requireNamespace("dplyr", quietly = TRUE)) {
+  install.packages("dplyr")
+}
+if (!requireNamespace("tidyr", quietly = TRUE)) {
+  install.packages("tidyr")
+}
+if (!requireNamespace("forcats", quietly = TRUE)) {
+  install.packages("forcats")
+}
+
+library(nanoparquet)
+library(ggplot2)
+library(dplyr)
+library(tidyr)
+library(forcats)
+
+# Parse command line arguments
+args <- commandArgs(trailingOnly = TRUE)
+input_file <- if(length(args) >= 1) args[1] else "collector-parquet.parquet"
+instruction_threshold <- if(length(args) >= 2) as.numeric(args[2]) else 100000  # Default to 100k instructions
+output_file <- if(length(args) >= 3) args[3] else "cpi_by_llc_misses"
+top_n_processes <- if(length(args) >= 4) as.numeric(args[4]) else 23  # Default to showing top 23 processes + "other"
+llc_percentile <- if(length(args) >= 5) as.numeric(args[5]) else 75  # Default to 75th percentile
+
+# Function to load and process parquet data
+load_and_process_parquet <- function(file_path) {
+  # Read the parquet file
+  message("Reading parquet file: ", file_path)
+  perf_data <- nanoparquet::read_parquet(file_path)
+  
+  # Replace NULL process names with "kernel" for better visualization
+  perf_data$process_name[is.na(perf_data$process_name)] <- "kernel"
+  
+  # Extract millisecond time slots from start_time (nanoseconds)
+  # We're assuming the timestamps are already aligned to millisecond boundaries
+  perf_data$ms_slot <- floor(perf_data$start_time / 1e6)
+  
+  # Calculate cycles per instruction (CPI) for each sample
+  perf_data$cpi <- perf_data$cycles / pmax(perf_data$instructions, 1)  # Avoid division by zero
+  
+  return(perf_data)
+}
+
+# Function to analyze LLC misses and create the faceted histogram
+create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes, llc_percentile) {
+  message("Analyzing LLC misses and CPI...")
+  
+  # Calculate aggregate LLC misses for each millisecond time slot
+  ms_aggregates <- data %>%
+    group_by(ms_slot) %>%
+    summarise(
+      total_llc_misses = sum(llc_misses, na.rm = TRUE),
+      .groups = "drop"
+    )
+  
+  # Determine the LLC misses threshold at the specified percentile
+  llc_threshold <- quantile(ms_aggregates$total_llc_misses, llc_percentile/100, na.rm = TRUE)
+  message(llc_percentile, "th percentile of LLC misses per millisecond: ", llc_threshold)
+
+  # Create category labels for the legend
+  high_label <- paste0("High LLC Misses (>", llc_percentile, "%)")
+  low_label <- paste0("Low LLC Misses (<", llc_percentile, "%)")
+
+  # Classify time slots as high or low LLC miss periods
+  ms_aggregates <- ms_aggregates %>%
+    mutate(llc_category = ifelse(total_llc_misses > llc_threshold, 
+                               high_label, 
+                               low_label))
+  
+  # Join the LLC category back to the original data
+  data_with_llc <- data %>%
+    left_join(ms_aggregates, by = "ms_slot")
+  
+  # Identify top processes by total instructions
+  top_processes <- data %>%
+    group_by(process_name) %>%
+    summarise(total_instructions = sum(instructions, na.rm = TRUE)) %>%
+    arrange(desc(total_instructions)) %>%
+    slice_head(n = top_n_processes) %>%
+    pull(process_name)
+  
+  message("Top ", length(top_processes), " processes by instructions:")
+  print(head(top_processes, 10))
+  
+  # Filter for significant samples (>instruction_threshold) and prepare for plotting
+  plot_data <- data_with_llc %>%
+    # Group all non-top processes as "other"
+    mutate(process_group = ifelse(process_name %in% top_processes, 
+                                 as.character(process_name), 
+                                 "other")) %>%
+    # Filter for samples with significant instruction counts
+    filter(instructions > instruction_threshold) %>%
+    # Cap extreme CPI values for better visualization
+    mutate(cpi_capped = pmin(cpi, 10))  # Cap at 10 cycles per instruction
+  
+  # Count samples per process for reporting
+  process_counts <- plot_data %>%
+    group_by(process_group, llc_category) %>%
+    summarise(
+      sample_count = n(),
+      avg_cpi = mean(cpi, na.rm = TRUE),
+      .groups = "drop"
+    )
+  
+  message("Sample counts and average CPI by process and LLC category:")
+  print(process_counts)
+  
+  # Ensure we have enough data to plot
+  if(nrow(plot_data) < 10) {
+    stop("Not enough data points after filtering. Try lowering the instruction threshold.")
+  }
+  
+  # Reorder factor levels based on total instructions for better visualization
+  process_order <- c(top_processes, "other")
+  plot_data$process_group <- factor(plot_data$process_group, levels = process_order)
+  
+  
+  # Create the faceted histogram plot
+  p <- ggplot(plot_data, aes(x = cpi_capped, fill = llc_category)) +
+    geom_histogram(position = "identity", alpha = 0.7, bins = 30) +
+    facet_wrap(~ process_group, scales = "free_y", ncol = 3) +
+    scale_fill_manual(values = c("#E41A1C", "#377EB8")) +
+    labs(
+      title = "Cycles Per Instruction (CPI) Distribution by Process",
+      subtitle = paste0("Comparing high vs. low LLC miss periods (threshold: ", 
+                       instruction_threshold, " instructions, ", llc_percentile, "% LLC miss percentile)"),
+      x = "Cycles Per Instruction (CPI)",
+      y = "Count",
+      fill = "LLC Miss Category"
+    ) +
+    theme_minimal() +
+    theme(
+      legend.position = "top",
+      strip.background = element_rect(fill = "lightgray"),
+      strip.text = element_text(face = "bold"),
+      plot.title = element_text(face = "bold"),
+      axis.title = element_text(face = "bold")
+    )
+  
+  return(p)
+}
+
+# Main execution
+main <- function() {
+  tryCatch({
+    # Check if input file exists
+    if (!file.exists(input_file)) {
+      stop("Input file does not exist: ", input_file)
+    }
+    
+    message("Processing performance data...")
+    perf_data <- load_and_process_parquet(input_file)
+    
+    # Check if we have enough data
+    if (nrow(perf_data) < 10) {
+      stop("Not enough data points in the input file.")
+    }
+    
+    message("Creating CPI by LLC misses plot...")
+    cpi_plot <- create_cpi_llc_analysis(perf_data, instruction_threshold, top_n_processes, llc_percentile)
+    
+    # Save outputs
+    png_filename <- paste0(output_file, ".png")
+    pdf_filename <- paste0(output_file, ".pdf")
+    
+    message("Saving output as PNG: ", png_filename)
+    ggsave(png_filename, cpi_plot, width = 15, height = 20, dpi = 300)
+    
+    message("Saving output as PDF: ", pdf_filename)
+    ggsave(pdf_filename, cpi_plot, width = 15, height = 20)
+    
+    message("Done!")
+  }, error = function(e) {
+    message("Error: ", e$message)
+    quit(status = 1)
+  })
+}
+
+# Execute main function
+main()

--- a/scripts/plot_cpi_by_llc_misses.R
+++ b/scripts/plot_cpi_by_llc_misses.R
@@ -32,14 +32,13 @@ library(forcats)
 # 2. instruction_threshold: Minimum number of instructions for a sample to be considered (default: 100000)
 # 3. output_file: Base name for output files without extension (default: cpi_by_llc_misses)
 # 4. top_n_processes: Number of top processes to show individually (default: 23)
-# 5. llc_percentile: Percentile threshold for high LLC misses (default: 75)
-# 6. start_time_seconds: Start time in seconds for the analysis window (default: 205)
-# 7. end_time_seconds: End time in seconds for the analysis window (default: 255)
+# 5. start_time_seconds: Start time in seconds for the analysis window (default: 205)
+# 6. end_time_seconds: End time in seconds for the analysis window (default: 255)
 #
 # Example usage:
-# Rscript plot_cpi_by_llc_misses.R my-data.parquet 50000 my-output 15 80 200 300
+# Rscript plot_cpi_by_llc_misses.R my-data.parquet 50000 my-output 15 200 300
 # This would use my-data.parquet, 50k instruction threshold, output to my-output.{png,pdf},
-# show top 15 processes, use 80th percentile LLC threshold, and analyze data from 200-300 seconds.
+# show top 15 processes, and analyze data from 200-300 seconds.
 
 # Parse command line arguments
 args <- commandArgs(trailingOnly = TRUE)
@@ -47,9 +46,8 @@ input_file <- if(length(args) >= 1) args[1] else "collector-parquet.parquet"
 instruction_threshold <- if(length(args) >= 2) as.numeric(args[2]) else 100000  # Default to 100k instructions
 output_file <- if(length(args) >= 3) args[3] else "cpi_by_llc_misses"
 top_n_processes <- if(length(args) >= 4) as.numeric(args[4]) else 23  # Default to showing top 23 processes + "other"
-llc_percentile <- if(length(args) >= 5) as.numeric(args[5]) else 75  # Default to 75th percentile
-start_time_seconds <- if(length(args) >= 6) as.numeric(args[6]) else 205  # Default steady state starts at 205 seconds
-end_time_seconds <- if(length(args) >= 7) as.numeric(args[7]) else 255  # Default steady state ends at 255 seconds
+start_time_seconds <- if(length(args) >= 5) as.numeric(args[5]) else 205  # Default steady state starts at 205 seconds
+end_time_seconds <- if(length(args) >= 6) as.numeric(args[6]) else 255  # Default steady state ends at 255 seconds
 
 # Function to load and process parquet data
 load_and_process_parquet <- function(file_path) {
@@ -74,9 +72,13 @@ load_and_process_parquet <- function(file_path) {
 }
 
 # Function to analyze LLC misses and create the faceted histogram
-create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes, llc_percentile, 
+create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes,
+                                   low_start_percentile, low_end_percentile,
+                                   high_start_percentile, high_end_percentile,
                                    start_time_seconds, end_time_seconds) {
-  message("Analyzing LLC misses and CPI...")
+  message(paste0("Analyzing LLC misses and CPI comparing ",
+                high_start_percentile, "-", high_end_percentile, "% vs ",
+                low_start_percentile, "-", low_end_percentile, "%..."))
   
   # Calculate aggregate LLC misses for each millisecond time slot
   ms_aggregates <- data %>%
@@ -86,19 +88,28 @@ create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes
       .groups = "drop"
     )
   
-  # Determine the LLC misses threshold at the specified percentile
-  llc_threshold <- quantile(ms_aggregates$total_llc_misses, llc_percentile/100, na.rm = TRUE)
-  message(llc_percentile, "th percentile of LLC misses per millisecond: ", llc_threshold)
+  # Determine the LLC misses thresholds for the given percentiles
+  low_start_threshold <- quantile(ms_aggregates$total_llc_misses, low_start_percentile/100, na.rm = TRUE)
+  low_end_threshold <- quantile(ms_aggregates$total_llc_misses, low_end_percentile/100, na.rm = TRUE)
+  high_start_threshold <- quantile(ms_aggregates$total_llc_misses, high_start_percentile/100, na.rm = TRUE)
+  high_end_threshold <- if(high_end_percentile == 100) Inf else quantile(ms_aggregates$total_llc_misses, high_end_percentile/100, na.rm = TRUE)
+  
+  message("Low LLC miss threshold (", low_start_percentile, "-", low_end_percentile, "%): ", 
+          low_start_threshold, " to ", low_end_threshold)
+  message("High LLC miss threshold (", high_start_percentile, "-", high_end_percentile, "%): ", 
+          high_start_threshold, " to ", high_end_threshold)
 
   # Create category labels for the legend
-  high_label <- paste0("High LLC Misses (>", llc_percentile, "%)")
-  low_label <- paste0("Low LLC Misses (<", llc_percentile, "%)")
+  high_label <- paste0("High LLC Misses (", high_start_percentile, "-", high_end_percentile, "%)")
+  low_label <- paste0("Low LLC Misses (", low_start_percentile, "-", low_end_percentile, "%)")
 
   # Classify time slots as high or low LLC miss periods
   ms_aggregates <- ms_aggregates %>%
-    mutate(llc_category = ifelse(total_llc_misses > llc_threshold, 
-                               high_label, 
-                               low_label))
+    mutate(llc_category = case_when(
+      total_llc_misses >= low_start_threshold & total_llc_misses <= low_end_threshold ~ low_label,
+      total_llc_misses > high_start_threshold & total_llc_misses <= high_end_threshold ~ high_label,
+      TRUE ~ "Other"
+    ))
   
   # Join the LLC category back to the original data
   data_with_llc <- data %>%
@@ -123,6 +134,8 @@ create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes
                                  "other")) %>%
     # Filter for samples with significant instruction counts
     filter(instructions > instruction_threshold) %>%
+    # Filter out the "Other" category
+    filter(llc_category != "Other") %>%
     # Cap extreme CPI values for better visualization
     mutate(cpi_capped = pmin(cpi, 10))  # Cap at 10 cycles per instruction
   
@@ -131,9 +144,11 @@ create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes
     group_by(process_group, llc_category) %>%
     summarise(
       sample_count = n(),
-      avg_cpi = mean(cpi, na.rm = TRUE),
+      total_cycles = sum(cycles, na.rm = TRUE),
+      total_instructions = sum(instructions, na.rm = TRUE),
       .groups = "drop"
-    )
+    ) %>%
+    mutate(avg_cpi = total_cycles / pmax(total_instructions, 1))
   
   message("Sample counts and average CPI by process and LLC category:")
   print(process_counts)
@@ -155,9 +170,11 @@ create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes
     scale_fill_manual(values = c("#E41A1C", "#377EB8")) +
     labs(
       title = "Cycles Per Instruction (CPI) Distribution by Process",
-      subtitle = paste0("Comparing high vs. low LLC miss periods (", 
-                       start_time_seconds, "-", end_time_seconds, "s window, ",
-                       instruction_threshold, " instructions, ", llc_percentile, "% LLC miss percentile)"),
+      subtitle = paste0("Comparing LLC miss percentiles: ", 
+                       high_start_percentile, "-", high_end_percentile, "% vs ", 
+                       low_start_percentile, "-", low_end_percentile, "% ",
+                       "(", start_time_seconds, "-", end_time_seconds, "s window, ",
+                       instruction_threshold, " instructions)"),
       x = "Cycles Per Instruction (CPI)",
       y = "Density",
       fill = "LLC Miss Category"
@@ -170,6 +187,157 @@ create_cpi_llc_analysis <- function(data, instruction_threshold, top_n_processes
       plot.title = element_text(face = "bold"),
       axis.title = element_text(face = "bold")
     )
+  
+  return(p)
+}
+
+# Function to create CPI slowdown bar plots comparing high LLC percentiles to low ones
+create_cpi_slowdown_plot <- function(data, instruction_threshold, top_n_processes,
+                                    low_start_percentile, low_end_percentile,
+                                    high_start_percentile, high_end_percentile,
+                                    start_time_seconds, end_time_seconds) {
+  message(paste0("Creating CPI slowdown plot comparing LLC misses ",
+                 high_start_percentile, "-", high_end_percentile, "% vs ",
+                 low_start_percentile, "-", low_end_percentile, "%..."))
+  
+  # Calculate aggregate LLC misses for each millisecond time slot
+  ms_aggregates <- data %>%
+    group_by(ms_slot) %>%
+    summarise(
+      total_llc_misses = sum(llc_misses, na.rm = TRUE),
+      .groups = "drop"
+    )
+  
+  # Determine the LLC misses thresholds for the given percentiles
+  low_start_threshold <- quantile(ms_aggregates$total_llc_misses, low_start_percentile/100, na.rm = TRUE)
+  low_end_threshold <- quantile(ms_aggregates$total_llc_misses, low_end_percentile/100, na.rm = TRUE)
+  high_start_threshold <- quantile(ms_aggregates$total_llc_misses, high_start_percentile/100, na.rm = TRUE)
+  high_end_threshold <- if(high_end_percentile == 100) Inf else quantile(ms_aggregates$total_llc_misses, high_end_percentile/100, na.rm = TRUE)
+  
+  message("Low LLC miss threshold (", low_start_percentile, "-", low_end_percentile, "%): ", 
+          low_start_threshold, " to ", low_end_threshold)
+  message("High LLC miss threshold (", high_start_percentile, "-", high_end_percentile, "%): ", 
+          high_start_threshold, " to ", high_end_threshold)
+  
+  # Classify time slots into low/high LLC miss categories
+  ms_aggregates <- ms_aggregates %>%
+    mutate(llc_category = case_when(
+      total_llc_misses >= low_start_threshold & total_llc_misses <= low_end_threshold ~ 
+        paste0(low_start_percentile, "-", low_end_percentile, "%"),
+      total_llc_misses > high_start_threshold & total_llc_misses <= high_end_threshold ~ 
+        paste0(high_start_percentile, "-", high_end_percentile, "%"),
+      TRUE ~ "Other"
+    ))
+  
+  # Join the LLC category back to the original data
+  data_with_llc <- data %>%
+    left_join(ms_aggregates, by = "ms_slot")
+  
+  # Identify top processes by total instructions
+  top_processes <- data %>%
+    group_by(process_name) %>%
+    summarise(total_instructions = sum(instructions, na.rm = TRUE)) %>%
+    arrange(desc(total_instructions)) %>%
+    slice_head(n = top_n_processes) %>%
+    pull(process_name)
+  
+  # Filter for significant samples and prepare for analysis
+  plot_data <- data_with_llc %>%
+    # Group all non-top processes as "other"
+    mutate(process_group = ifelse(process_name %in% top_processes, 
+                                 as.character(process_name), 
+                                 "other")) %>%
+    # Filter for samples with significant instruction counts
+    filter(instructions > instruction_threshold) %>%
+    # Keep only low and high LLC categories
+    filter(llc_category != "Other")
+  
+  # Calculate aggregate cycles and instructions for each process and LLC category,
+  # then compute CPI from these aggregates
+  cpi_by_category <- plot_data %>%
+    group_by(process_group, llc_category) %>%
+    summarise(
+      total_cycles = sum(cycles, na.rm = TRUE),
+      total_instructions = sum(instructions, na.rm = TRUE),
+      sample_count = n(),
+      .groups = "drop"
+    ) %>%
+    mutate(aggregate_cpi = total_cycles / pmax(total_instructions, 1))  # Avoid division by zero
+  
+  # Ensure we have data for both categories for each process
+  process_categories <- cpi_by_category %>%
+    group_by(process_group) %>%
+    summarise(category_count = n_distinct(llc_category), .groups = "drop") %>%
+    filter(category_count == 2) %>%
+    pull(process_group)
+  
+  if(length(process_categories) == 0) {
+    stop("No processes have data for both LLC miss categories. Consider adjusting thresholds or using more data.")
+  }
+  
+  # Filter to include only processes with both categories
+  cpi_by_category <- cpi_by_category %>%
+    filter(process_group %in% process_categories)
+  
+  # Reshape the data to calculate slowdown ratios
+  cpi_wide <- cpi_by_category %>%
+    select(process_group, llc_category, aggregate_cpi) %>%
+    pivot_wider(
+      id_cols = process_group,
+      names_from = llc_category,
+      values_from = aggregate_cpi
+    )
+  
+  low_col <- paste0(low_start_percentile, "-", low_end_percentile, "%")
+  high_col <- paste0(high_start_percentile, "-", high_end_percentile, "%")
+  
+  # Calculate slowdown ratio
+  cpi_wide$slowdown_ratio <- cpi_wide[[high_col]] / cpi_wide[[low_col]]
+  
+  # Prepare data for plotting
+  plot_data_ratio <- cpi_wide %>%
+    select(process_group, slowdown_ratio) %>%
+    # Sort by slowdown ratio
+    arrange(desc(slowdown_ratio))
+  
+  # Reorder factor levels based on slowdown ratio for better visualization
+  process_order <- plot_data_ratio$process_group
+  plot_data_ratio$process_group <- factor(plot_data_ratio$process_group, 
+                                         levels = process_order)
+  
+  # Create the bar plot
+  p <- ggplot(plot_data_ratio, aes(x = process_group, y = slowdown_ratio, fill = slowdown_ratio)) +
+    geom_bar(stat = "identity") +
+    geom_text(aes(label = sprintf("%.2fx", slowdown_ratio)), 
+              vjust = -0.5, size = 6) +
+    scale_fill_gradient(low = "#377EB8", high = "#E41A1C") +
+    labs(
+      title = paste0("CPI Slowdown: ", high_start_percentile, "-", high_end_percentile, 
+                   "% vs ", low_start_percentile, "-", low_end_percentile, "% LLC Misses"),
+      subtitle = paste0("Analysis of ", start_time_seconds, "-", end_time_seconds, 
+                       "s window, ", instruction_threshold, " instruction threshold"),
+      x = "Process",
+      y = "CPI Slowdown Factor",
+      fill = "Slowdown"
+    ) +
+    theme_minimal() +
+    theme(
+      legend.position = "none",
+      plot.title = element_text(face = "bold", size = 24),
+      plot.subtitle = element_text(size = 18),
+      axis.title = element_text(face = "bold", size = 18),
+      axis.text.x = element_text(angle = 60, hjust = 1, size = 16),
+      axis.text.y = element_text(size = 14)
+    )
+  
+  # Print summary statistics
+  message("CPI slowdown statistics:")
+  summary_stats <- summary(plot_data_ratio$slowdown_ratio)
+  print(summary_stats)
+  
+  # Print top slowdowns
+  message("Top 5 processes by CPI slowdown:")
+  print(head(plot_data_ratio, 5))
   
   return(p)
 }
@@ -204,19 +372,67 @@ main <- function() {
                    nrow(perf_data_filtered), nrow(perf_data), 
                    100 * nrow(perf_data_filtered) / nrow(perf_data)))
     
-    message("Creating CPI by LLC misses plot...")
-    cpi_plot <- create_cpi_llc_analysis(perf_data_filtered, instruction_threshold, top_n_processes, llc_percentile, 
-                                         start_time_seconds, end_time_seconds)
+    # Create the CPI distribution plots comparing different LLC miss ranges
+    message("Creating CPI distribution plots...")
     
-    # Save outputs
-    png_filename <- paste0(output_file, ".png")
-    pdf_filename <- paste0(output_file, ".pdf")
+    # 1. Top 5% vs Bottom 95%
+    cpi_plot_5_vs_95 <- create_cpi_llc_analysis(perf_data_filtered, instruction_threshold, 
+                                              top_n_processes, 0, 95, 95, 100, 
+                                              start_time_seconds, end_time_seconds)
     
-    message("Saving output as PNG: ", png_filename)
-    ggsave(png_filename, cpi_plot, width = 15, height = 20, dpi = 300)
+    # 2. Top 5% vs Middle 45-55%
+    cpi_plot_5_vs_mid <- create_cpi_llc_analysis(perf_data_filtered, instruction_threshold, 
+                                               top_n_processes, 45, 55, 95, 100, 
+                                               start_time_seconds, end_time_seconds)
     
-    message("Saving output as PDF: ", pdf_filename)
-    ggsave(pdf_filename, cpi_plot, width = 15, height = 20)
+    # Create the CPI slowdown bar plots
+    # 1. Top 5% vs Bottom 95%
+    slowdown_plot_5_vs_95 <- create_cpi_slowdown_plot(perf_data_filtered, instruction_threshold, 
+                                                     top_n_processes, 0, 95, 95, 100, 
+                                                     start_time_seconds, end_time_seconds)
+    
+    # 2. Top 5% vs Middle 45-55%
+    slowdown_plot_5_vs_mid <- create_cpi_slowdown_plot(perf_data_filtered, instruction_threshold, 
+                                                     top_n_processes, 45, 55, 95, 100, 
+                                                     start_time_seconds, end_time_seconds)
+    
+    # Save outputs for CPI distribution plots
+    cpi_plot_5_vs_95_png <- paste0(output_file, "_dist_top5_vs_bottom95.png")
+    cpi_plot_5_vs_95_pdf <- paste0(output_file, "_dist_top5_vs_bottom95.pdf")
+    
+    message("Saving top 5% vs bottom 95% distribution plot as PNG: ", cpi_plot_5_vs_95_png)
+    ggsave(cpi_plot_5_vs_95_png, cpi_plot_5_vs_95, width = 15, height = 20, dpi = 300)
+    
+    message("Saving top 5% vs bottom 95% distribution plot as PDF: ", cpi_plot_5_vs_95_pdf)
+    ggsave(cpi_plot_5_vs_95_pdf, cpi_plot_5_vs_95, width = 15, height = 20)
+    
+    cpi_plot_5_vs_mid_png <- paste0(output_file, "_dist_top5_vs_mid45-55.png")
+    cpi_plot_5_vs_mid_pdf <- paste0(output_file, "_dist_top5_vs_mid45-55.pdf")
+    
+    message("Saving top 5% vs middle 45-55% distribution plot as PNG: ", cpi_plot_5_vs_mid_png)
+    ggsave(cpi_plot_5_vs_mid_png, cpi_plot_5_vs_mid, width = 15, height = 20, dpi = 300)
+    
+    message("Saving top 5% vs middle 45-55% distribution plot as PDF: ", cpi_plot_5_vs_mid_pdf)
+    ggsave(cpi_plot_5_vs_mid_pdf, cpi_plot_5_vs_mid, width = 15, height = 20)
+    
+    # Save outputs for slowdown plots
+    slowdown_5_vs_95_png <- paste0(output_file, "_slowdown_top5_vs_bottom95.png")
+    slowdown_5_vs_95_pdf <- paste0(output_file, "_slowdown_top5_vs_bottom95.pdf")
+    
+    message("Saving top 5% vs bottom 95% slowdown plot as PNG: ", slowdown_5_vs_95_png)
+    ggsave(slowdown_5_vs_95_png, slowdown_plot_5_vs_95, width = 15, height = 10, dpi = 300)
+    
+    message("Saving top 5% vs bottom 95% slowdown plot as PDF: ", slowdown_5_vs_95_pdf)
+    ggsave(slowdown_5_vs_95_pdf, slowdown_plot_5_vs_95, width = 15, height = 10)
+    
+    slowdown_5_vs_mid_png <- paste0(output_file, "_slowdown_top5_vs_mid45-55.png")
+    slowdown_5_vs_mid_pdf <- paste0(output_file, "_slowdown_top5_vs_mid45-55.pdf")
+    
+    message("Saving top 5% vs middle 45-55% slowdown plot as PNG: ", slowdown_5_vs_mid_png)
+    ggsave(slowdown_5_vs_mid_png, slowdown_plot_5_vs_mid, width = 15, height = 10, dpi = 300)
+    
+    message("Saving top 5% vs middle 45-55% slowdown plot as PDF: ", slowdown_5_vs_mid_pdf)
+    ggsave(slowdown_5_vs_mid_pdf, slowdown_plot_5_vs_mid, width = 15, height = 10)
     
     message("Done!")
   }, error = function(e) {


### PR DESCRIPTION
# OpenTelemetry Demo Benchmark Scaling Changes

This PR addresses scaling the OpenTelemetry demo benchmark to support higher workloads. Below is a summary of the changes implemented:

## Infrastructure Improvements
- **Multi-region support for self-hosted runners**: Increased reliability of spot instance allocation by adding support for multiple regions
- **Replica scaling**: 
  - Increased the number of replicas across the system
  - Implemented non-uniform scaling for services with different requirements
- **Memory limit adjustments**:
  - Increased memory limits that were previously set too low
  - Applied different memory limits for different pods based on their needs

## Load Generator Optimizations
- **Performance enhancement**: Switched from HTTP User (Locust interface) to Fast HTTP User to reduce overhead
- **Statistics output**: 
  - Grouped product accesses together instead of having one per URL
  - Now showing P95/P99 per workflow rather than per URL
  - Updated associated plots
- **Startup behavior**: Eliminated redundant root fetching on every new user to improve ramp-up phase performance
- **Configurable experiment length**: Added parameter to extend steady-state run time beyond the default 60 seconds (useful for longer 30-minute experiments)

## Telemetry Adjustments
- **Selective OpenTelemetry exporter disabling**: 
  - Disabled exporters on many services to reduce cycle consumption
  - Re-enabled for services that failed without OpenTelemetry support
  - Note: Complete disabling of the OpenTelemetry collector didn't work for some services (unexpected behavior worth documenting)

## Monitoring Enhancements
- **CPU utilization**: Added CPU bar chart showing largest CPU consumers over time
- **Pod status**: Added output of pod status at end of GitHub Actions workflow to detect restarts
- **Cache performance**:
  - Added LLC (Last Level Cache) miss plots to be automatically generated
  - Added CPI (Cycles Per Instruction) by LLC misses plot showing distributions
  - Added CPI slowdown plot showing performance impact when cache misses are high vs. median
- **Timing adjustments**: Accounted for time difference between collector and load generator starts (20-30 seconds) when plotting steady-state metrics

## Known Issues
- The ads workflow in load generation still produces 100% errors (not fixed in this PR)