### PR TITLE
add support for relative timers, down to kernel 5.15

### DIFF
--- a/.github/workflows/test-ebpf-collector.yaml
+++ b/.github/workflows/test-ebpf-collector.yaml
@@ -190,7 +190,7 @@ jobs:
             # Run the collector and capture both stdout and stderr
             echo "Running collector for 5 seconds..."
             set +e  # Don't exit on error
-            ./artifacts/collector -d 5 --storage-type local --prefix "/tmp/test-output/metrics-" > /tmp/collector-output.log 2>&1
+            RUST_LOG=debug ./artifacts/collector -d 5 --storage-type local --prefix "/tmp/test-output/metrics-" --verbose > /tmp/collector-output.log 2>&1
             COLLECTOR_EXIT_CODE=$?
             set -e
             

--- a/.github/workflows/test-ebpf-collector.yaml
+++ b/.github/workflows/test-ebpf-collector.yaml
@@ -94,18 +94,18 @@ jobs:
           # Test on kernel 6.1 - should fail with clear error message about kernel requirement
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '6.1-20250507.063028'
-            should_succeed: false
-            description: 'Kernel 6.1 (should fail - does not have absolute timer support)'
+            should_succeed: true
+            description: 'Kernel 6.1 (should succeed - legacy timer mode - relative time supported)'
           # Test on kernel 6.6 - should fail with clear error message about kernel requirement  
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '6.6-20250507.063028'
             should_succeed: true
-            description: 'Kernel 6.6 (should succeed - legacy timer initialization)'
+            description: 'Kernel 6.6 (should succeed - intermediate timer mode - absolute time supported)'
           # Test on kernel 6.12 - should succeed (6.7+ supports CPU pinning)
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '6.12-20250507.063028'
             should_succeed: true
-            description: 'Kernel 6.12 (should succeed - CPU pinning supported)'
+            description: 'Kernel 6.12 (should succeed - modern timer mode - CPU pinning + absolute time supported)'
     timeout-minutes: 5
     steps:
       - name: Checkout code

--- a/.github/workflows/test-ebpf-collector.yaml
+++ b/.github/workflows/test-ebpf-collector.yaml
@@ -124,8 +124,7 @@ jobs:
           name: collector-binary
           path: ./artifacts
 
-      - name: Provision LVH VM and Test
-        # uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+      - name: Provision LVH VM
         uses: yonch/little-vm-helper@main
         with:
           test-name: collector-kernel-${{ matrix.kernel }}
@@ -145,7 +144,6 @@ jobs:
             
             git config --global --add safe.directory /host
             uname -a
-            echo "Testing memory collector on kernel: ${{ matrix.description }}"
             
             # Check if perf events are available
             echo "Checking perf event capabilities..."
@@ -168,11 +166,12 @@ jobs:
             echo mounts:
             mount
 
-            echo "Debug: Dollar-question-mark value: $?"
-            COLLECTOR_EXIT_CODE=0
-            echo "Debug: Assigned value: $COLLECTOR_EXIT_CODE"
-            echo "Debug: Assigned value (escaped dollar sign): \$COLLECTOR_EXIT_CODE"
-
+      - name: Test Collector on ${{ matrix.description }}
+        uses: yonch/little-vm-helper@main
+        with:
+          provision: 'false'
+          cmd: |
+            echo "Testing memory collector on kernel: ${{ matrix.description }}"
             uname -a
             cd /host
             

--- a/.github/workflows/test-ebpf-collector.yaml
+++ b/.github/workflows/test-ebpf-collector.yaml
@@ -91,23 +91,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - kernel: '5.10'
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
+          - kernel: '5.10-20250507.063028'
             should_succeed: false
             description: 'Kernel 5.10 (should fail - does not have bpf timer support)'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.15'
+          - kernel: '5.15-20250507.063028'
             should_succeed: true
             description: 'Kernel 5.15 (should succeed - legacy timer mode - relative time supported)'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.1'
+          - kernel: '6.1-20250507.063028'
             should_succeed: true
             description: 'Kernel 6.1 (should succeed - legacy timer mode - relative time supported)'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.6'
+          - kernel: '6.6-20250507.063028'
             should_succeed: true
             description: 'Kernel 6.6 (should succeed - intermediate timer mode - absolute time supported)'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.12'
+          - kernel: '6.12-20250507.063028'
             should_succeed: true
             description: 'Kernel 6.12 (should succeed - modern timer mode - CPU pinning + absolute time supported)'
     timeout-minutes: 5

--- a/.github/workflows/test-ebpf-collector.yaml
+++ b/.github/workflows/test-ebpf-collector.yaml
@@ -91,19 +91,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Test on kernel 6.1 - should fail with clear error message about kernel requirement
+          - kernel: '5.10'
+            should_succeed: false
+            description: 'Kernel 5.10 (should fail - does not have bpf timer support)'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.1-20250507.063028'
+          - kernel: '5.15'
+            should_succeed: true
+            description: 'Kernel 5.15 (should succeed - legacy timer mode - relative time supported)'
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
+          - kernel: '6.1'
             should_succeed: true
             description: 'Kernel 6.1 (should succeed - legacy timer mode - relative time supported)'
-          # Test on kernel 6.6 - should fail with clear error message about kernel requirement  
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.6-20250507.063028'
+          - kernel: '6.6'
             should_succeed: true
             description: 'Kernel 6.6 (should succeed - intermediate timer mode - absolute time supported)'
-          # Test on kernel 6.12 - should succeed (6.7+ supports CPU pinning)
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.12-20250507.063028'
+          - kernel: '6.12'
             should_succeed: true
             description: 'Kernel 6.12 (should succeed - modern timer mode - CPU pinning + absolute time supported)'
     timeout-minutes: 5

--- a/.github/workflows/test-ebpf-collector.yaml
+++ b/.github/workflows/test-ebpf-collector.yaml
@@ -123,6 +123,14 @@ jobs:
         with:
           name: collector-binary
           path: ./artifacts
+        
+      - name: Copy pqrs to workspace for guest access
+        run: |
+          # Create a tools directory in the workspace
+          mkdir -p tools
+          # Copy pqrs binary to the workspace so it's accessible in the guest VM
+          cp -f /usr/local/bin/pqrs tools/
+          chmod +x tools/pqrs
 
       - name: Provision LVH VM
         uses: yonch/little-vm-helper@main
@@ -384,14 +392,6 @@ jobs:
           sudo mv pqrs-0.3.2-x86_64-unknown-linux-gnu/bin/pqrs /usr/local/bin/
           sudo chmod +x /usr/local/bin/pqrs
           rm -rf pqrs.zip pqrs-0.3.2-x86_64-unknown-linux-gnu
-
-      - name: Copy pqrs to workspace for guest access
-        run: |
-          # Create a tools directory in the workspace
-          mkdir -p tools
-          # Copy pqrs binary to the workspace so it's accessible in the guest VM
-          cp /usr/local/bin/pqrs tools/
-          chmod +x tools/pqrs
 
       - name: Install Podman and Docker compatibility
         run: |

--- a/.github/workflows/test-ebpf-collector.yaml
+++ b/.github/workflows/test-ebpf-collector.yaml
@@ -255,6 +255,32 @@ jobs:
             
             echo "=== Test completed for ${{ matrix.description }} ==="
 
+      - name: Display parquet file contents
+        if: matrix.should_succeed == true
+        uses: yonch/little-vm-helper@main
+        with:
+          provision: 'false'
+          cmd: |
+            echo "=== Displaying parquet file contents for ${{ matrix.description }} ==="
+            cd /host
+            
+            # Find all parquet files in /tmp/test-output
+            if ls /tmp/test-output/metrics-*.parquet >/dev/null 2>&1; then
+              echo "Found parquet files:"
+              ls -la /tmp/test-output/metrics-*.parquet
+              echo
+              
+              # Display contents of each parquet file using pqrs from the tools directory
+              for parquet_file in /tmp/test-output/metrics-*.parquet; do
+                echo "=== Contents of $(basename $parquet_file) ==="
+                /host/tools/pqrs cat --csv "$parquet_file" || echo "Failed to read parquet file: $parquet_file"
+                echo
+              done
+            else
+              echo "No parquet files found in /tmp/test-output/"
+            fi
+            echo "=== End of parquet file contents ==="
+
       - name: Stop qemu
         if: always()
         run: |
@@ -358,6 +384,14 @@ jobs:
           sudo mv pqrs-0.3.2-x86_64-unknown-linux-gnu/bin/pqrs /usr/local/bin/
           sudo chmod +x /usr/local/bin/pqrs
           rm -rf pqrs.zip pqrs-0.3.2-x86_64-unknown-linux-gnu
+
+      - name: Copy pqrs to workspace for guest access
+        run: |
+          # Create a tools directory in the workspace
+          mkdir -p tools
+          # Copy pqrs binary to the workspace so it's accessible in the guest VM
+          cp /usr/local/bin/pqrs tools/
+          chmod +x tools/pqrs
 
       - name: Install Podman and Docker compatibility
         run: |

--- a/crates/bpf/src/bpf/sync_timer.bpf.h
+++ b/crates/bpf/src/bpf/sync_timer.bpf.h
@@ -3,6 +3,19 @@
 #define NSEC_PER_MSEC 1000000ULL
 #define CLOCK_MONOTONIC 1
 
+/* Define AF_INET constant for BPF context */
+#define AF_INET 2
+
+/* Timer initialization modes */
+enum sync_timer_mode {
+    SYNC_TIMER_MODE_MODERN = 0,      // CPU pinning + absolute time (kernel 6.7+)
+    SYNC_TIMER_MODE_INTERMEDIATE = 1, // Absolute time only (kernel 6.4-6.6)
+    SYNC_TIMER_MODE_LEGACY = 2,      // Relative time only (kernel 5.15-6.3)
+};
+
+// Dummy instance to make skeleton generation work
+enum sync_timer_mode sync_timer_mode_ = 0;
+
 /* Error codes for sync timer initialization */
 enum sync_timer_init_error {
     SYNC_TIMER_SUCCESS = 0,
@@ -23,6 +36,7 @@ struct sync_timer_state {
     __u64 next_expected;  // Absolute time for next tick
     __u32 expected_cpu;   // CPU ID this timer should fire on
     __u64 timer_flags;    // Pre-computed timer flags for bpf_timer_start()
+    __u8 init_mode;       // Initialization mode (0=modern, 1=intermediate, 2=legacy)
 };
 
 /* Helper function to calculate absolute difference */
@@ -33,6 +47,23 @@ static __always_inline __u64 __sync_timer_abs_diff(__u64 a, __u64 b) {
 /* Helper function to align time to next interval */
 static __always_inline __u64 __sync_timer_align_to_interval(__u64 time, __u64 interval) {
     return (time / interval) * interval;
+}
+
+/* Helper function to compute timer start parameter based on flags and expected time */
+static __always_inline __u64 __sync_timer_compute_start_param(__u64 next_expected, __u64 timer_flags) {
+    if (timer_flags & BPF_F_TIMER_ABS) {
+        /* Absolute time mode - return the expected time directly */
+        return next_expected;
+    } else {
+        /* Relative time mode - compute relative offset from current time */
+        __u64 now = bpf_ktime_get_ns();
+        if (next_expected > now) {
+            return next_expected - now;
+        } else {
+            /* If expected time is in the past, schedule for immediate execution */
+            return 1;
+        }
+    }
 }
 
 /* Shared timer callback implementation */
@@ -64,8 +95,9 @@ static __always_inline int __sync_timer_shared_callback(
     /* Calculate next absolute time for timer */
     state->next_expected = __sync_timer_align_to_interval(now + NSEC_PER_MSEC, NSEC_PER_MSEC);
 
-    /* Reschedule timer using pre-computed flags */
-    bpf_timer_start(&state->timer, state->next_expected, state->timer_flags);
+    /* Reschedule timer using computed start parameter */
+    __u64 start_param = __sync_timer_compute_start_param(state->next_expected, state->timer_flags);
+    bpf_timer_start(&state->timer, start_param, state->timer_flags);
 
     return 0;
 }
@@ -74,7 +106,7 @@ static __always_inline int __sync_timer_shared_callback(
 static __always_inline int __sync_timer_shared_init(
     void *timer_states_map,
     int (*timer_callback)(void *, int *, struct sync_timer_state *),
-    __u8 use_legacy_mode
+    __u8 init_mode
 ) {
     __u32 cpu = bpf_get_smp_processor_id();
     struct sync_timer_state *state;
@@ -82,7 +114,19 @@ static __always_inline int __sync_timer_shared_init(
     int ret;
 
     /* Pre-compute timer flags based on mode */
-    __u64 timer_flags = use_legacy_mode ? BPF_F_TIMER_ABS : (BPF_F_TIMER_ABS | BPF_F_TIMER_CPU_PIN);
+    __u64 timer_flags;
+    switch (init_mode) {
+        case SYNC_TIMER_MODE_MODERN:
+            timer_flags = BPF_F_TIMER_ABS | BPF_F_TIMER_CPU_PIN;
+            break;
+        case SYNC_TIMER_MODE_INTERMEDIATE:
+            timer_flags = BPF_F_TIMER_ABS;
+            break;
+        case SYNC_TIMER_MODE_LEGACY:
+        default:
+            timer_flags = 0;  // No flags for legacy mode
+            break;
+    }
 
     /* Check if timer state already exists for this CPU and remove it to start fresh */
     state = bpf_map_lookup_elem(timer_states_map, &cpu);
@@ -97,6 +141,7 @@ static __always_inline int __sync_timer_shared_init(
     struct sync_timer_state new_state = {};
     new_state.expected_cpu = cpu;  // Store the CPU this timer should fire on
     new_state.timer_flags = timer_flags;
+    new_state.init_mode = init_mode;
     ret = bpf_map_update_elem(timer_states_map, &cpu, &new_state, BPF_ANY);
     if (ret < 0) {
         return SYNC_TIMER_MAP_UPDATE_FAILED;
@@ -122,8 +167,9 @@ static __always_inline int __sync_timer_shared_init(
         return SYNC_TIMER_TIMER_SET_CALLBACK_FAILED;
     }
     
-    /* Start timer using pre-computed flags */
-    ret = bpf_timer_start(&state->timer, state->next_expected, timer_flags);
+    /* Start timer using computed start parameter */
+    __u64 start_param = __sync_timer_compute_start_param(state->next_expected, timer_flags);
+    ret = bpf_timer_start(&state->timer, start_param, timer_flags);
     if (ret < 0) {
         return SYNC_TIMER_TIMER_START_FAILED;
     }
@@ -148,16 +194,15 @@ static int sync_timer_callback_##timer_name(void *map, int *key, struct sync_tim
     return __sync_timer_shared_callback(map, key, state, callback_func); \
 } \
 \
-/* Modern timer initialization function */ \
+/* Unified timer initialization function with mode parameter */ \
 SEC("syscall") \
 int sync_timer_init_##timer_name(struct bpf_sock_addr *ctx) \
 { \
-    return __sync_timer_shared_init(&sync_timer_states_##timer_name, sync_timer_callback_##timer_name, 0); \
-} \
-\
-/* Legacy fallback timer initialization function */ \
-SEC("syscall") \
-int sync_timer_init_legacy_##timer_name(struct bpf_sock_addr *ctx) \
-{ \
-    return __sync_timer_shared_init(&sync_timer_states_##timer_name, sync_timer_callback_##timer_name, 1); \
+    /* Extract mode from context_in if available, default to modern mode */ \
+    __u8 init_mode = SYNC_TIMER_MODE_MODERN; \
+    if (ctx && ctx->user_family == AF_INET) { \
+        /* Use the first byte of user_ip4 as the mode parameter */ \
+        init_mode = (__u8)(ctx->user_ip4 & 0xFF); \
+    } \
+    return __sync_timer_shared_init(&sync_timer_states_##timer_name, sync_timer_callback_##timer_name, init_mode); \
 } 

--- a/crates/bpf/src/lib.rs
+++ b/crates/bpf/src/lib.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
-use libbpf_rs::OpenObject;
+use libbpf_rs::{set_print, OpenObject, PrintLevel};
 use perf_events::{Dispatcher, HardwareCounter, PerfMapReader};
 use std::mem::MaybeUninit;
 use std::time::Duration;
@@ -44,26 +44,32 @@ pub struct BpfLoader {
 
 impl BpfLoader {
     /// Create a new BPF loader with initialized skeleton
-    pub fn new(verbose: bool) -> Result<Self> {
-        // Allow the current process to lock memory for eBPF resources
-        let _ = libbpf_rs::set_print(None);
-
-        // Open BPF program
-        let mut skel_builder = bpf::CollectorSkelBuilder::default();
-        if verbose {
-            skel_builder.obj_builder.debug(true);
+    pub fn new() -> Result<Self> {
+        fn print_to_log(level: PrintLevel, msg: String) {
+            match level {
+                PrintLevel::Debug => log::debug!("{}", msg),
+                PrintLevel::Info => log::info!("{}", msg),
+                PrintLevel::Warn => log::warn!("{}", msg),
+            }
         }
 
-        // Create and leak the storage to give it a 'static lifetime
-        // This is a controlled memory leak, but it's acceptable because:
-        // 1. It happens once per program run
-        // 2. It's needed to make the lifetime mechanics work properly
-        // 3. The memory will be reclaimed when the program exits
-        let obj_ref = Box::leak(Box::new(MaybeUninit::<OpenObject>::uninit()));
+        set_print(Some((PrintLevel::Debug, print_to_log)));
 
-        // Open and load the skeleton with 'static lifetime
-        let open_skel = skel_builder.open(obj_ref)?;
-        let mut skel = open_skel.load()?;
+        // Load BPF program (non-verbose, use the log crate to print errors)
+        let skel_result = Self::load_skel(false);
+
+        if let Err(e) = skel_result {
+            log::error!("Failed to load BPF program: {}", e);
+            log::error!("Reloading with debug flag, for more information");
+
+            // Reload with debug flag (verbose, to always print the error to stderr)
+            let _ = Self::load_skel(true);
+
+            // Return the original error
+            return Err(e);
+        }
+
+        let mut skel = skel_result.expect("checked above that it's not an error");
 
         // Initialize perf event rings for the hardware counters
         if let Err(e) =
@@ -100,6 +106,25 @@ impl BpfLoader {
             dispatcher,
             perf_map_reader,
         })
+    }
+
+    fn load_skel(verbose: bool) -> Result<bpf::CollectorSkel<'static>> {
+        let mut skel_builder = bpf::CollectorSkelBuilder::default();
+        if verbose {
+            skel_builder.obj_builder.debug(true);
+        }
+
+        // Create and leak the storage to give it a 'static lifetime
+        // This is a controlled memory leak, but it's acceptable because:
+        // 1. It happens once per program run
+        // 2. It's needed to make the lifetime mechanics work properly
+        // 3. The memory will be reclaimed when the program exits
+        let obj_ref = Box::leak(Box::new(MaybeUninit::<OpenObject>::uninit()));
+
+        let open_skel = skel_builder.open(obj_ref)?;
+        open_skel
+            .load()
+            .with_context(|| "Failed to load BPF program")
     }
 
     /// Get a reference to the perf events dispatcher

--- a/crates/bpf/src/lib.rs
+++ b/crates/bpf/src/lib.rs
@@ -19,8 +19,8 @@ mod test_bpf {
 
 // Re-export the specific types we need
 pub use bpf::types::{
-    msg_type, perf_measurement_msg as PerfMeasurementMsg, task_free_msg as TaskFreeMsg,
-    task_metadata_msg as TaskMetadataMsg,
+    msg_type, perf_measurement_msg as PerfMeasurementMsg, sync_timer_mode,
+    task_free_msg as TaskFreeMsg, task_metadata_msg as TaskMetadataMsg,
     timer_finished_processing_msg as TimerFinishedProcessingMsg,
     timer_migration_msg as TimerMigrationMsg,
 };
@@ -114,11 +114,8 @@ impl BpfLoader {
 
     /// Initialize and start the sync timer
     pub fn start_sync_timer(&mut self) -> Result<()> {
-        sync_timer::initialize_sync_timer(
-            &self.skel.progs.sync_timer_init_collect,
-            &self.skel.progs.sync_timer_init_legacy_collect,
-        )
-        .map_err(|e| anyhow::anyhow!("Sync timer initialization failed: {}", e))
+        sync_timer::initialize_sync_timer(&self.skel.progs.sync_timer_init_collect)
+            .map_err(|e| anyhow::anyhow!("Sync timer initialization failed: {}", e))
     }
 
     /// Attach BPF programs

--- a/crates/bpf/src/sync_timer.rs
+++ b/crates/bpf/src/sync_timer.rs
@@ -279,7 +279,10 @@ fn initialize_timers_on_all_cores(
     // Initialize timer on each core sequentially
     for cpu_id in 0..num_possible_cpus {
         if let Err(e) = initialize_timer_on_core(timer_init_prog, cpu_id, current_pid, mode) {
-            error!("Timer initialization failed on core {}: {}", cpu_id, e);
+            debug!(
+                "Timer initialization failed on core {} with strategy {} (this is one of multiple fallback attempts): {}",
+                cpu_id, mode.description(), e
+            );
             failed_cores.push(cpu_id);
         } else {
             debug!("Timer initialization succeeded on core {}", cpu_id);

--- a/crates/collector/src/main.rs
+++ b/crates/collector/src/main.rs
@@ -305,7 +305,7 @@ fn main() -> Result<()> {
     let object_writer_sender = writer_task.sender();
 
     // Create a BPF loader with the specified verbosity
-    let mut bpf_loader = BpfLoader::new(opts.verbose)?;
+    let mut bpf_loader = BpfLoader::new()?;
 
     // Initialize the sync timer
     bpf_loader.start_sync_timer()?;


### PR DESCRIPTION
closes #182

- add kernels 5.15 and 5.10 to multi-kernel tests
- display parquet files when kernel test successful
- improve logging when BPF load fails: use the log crate and add a debug log on failure
- add legacy support for relative timers
- removed bpf_map_lookup_percpu_elem dependency (that required 5.19+)