### PR TITLE
(crates/collector) Use logging framework instead of `println/eprintln`

### DIFF
--- a/crates/collector/src/main.rs
+++ b/crates/collector/src/main.rs
@@ -478,7 +478,7 @@ fn main() -> Result<()> {
                 _ = sigusr1.recv() => {
                     debug!("Received SIGUSR1, rotating parquet file");
                     if let Err(e) = writer_task.rotate().await {
-                        log::error!("Failed to rotate parquet file: {}", e);
+                        error!("Failed to rotate parquet file: {}", e);
                     }
                     // Continue running, don't break
                 },
@@ -487,10 +487,10 @@ fn main() -> Result<()> {
                 error = &mut bpf_error_rx => {
                     match error {
                         Ok(error_msg) => {
-                            log::error!("{}", error_msg);
+                            error!("{}", error_msg);
                         },
                         Err(_) => {
-                            log::error!("BPF polling channel closed unexpectedly");
+                            error!("BPF polling channel closed unexpectedly");
                         }
                     }
                     break;
@@ -501,11 +501,11 @@ fn main() -> Result<()> {
                     let shutdown_reason = match result {
                         Ok(Ok(_)) => "Writer task returned unexpectedly",
                         Ok(Err(e)) => {
-                            log::error!("Writer task error: {}", e);
+                            error!("Writer task error: {}", e);
                             "Writer task failed with error"
                         },
                         Err(e) => {
-                            log::error!("Writer task panicked: {}", e);
+                            error!("Writer task panicked: {}", e);
                             "Writer task panicked"
                         }
                     };
@@ -523,7 +523,7 @@ fn main() -> Result<()> {
         debug!("Waiting for writer task to complete...");
         let writer_task_result = writer_task.shutdown().await;
         if let Err(e) = writer_task_result {
-            log::error!("Writer task error: {}", e);
+            error!("Writer task error: {}", e);
             return Result::<_>::Err(anyhow::anyhow!("Writer task error: {}", e));
         }
 
@@ -552,7 +552,7 @@ fn main() -> Result<()> {
 
     // Clean up: wait for monitoring task to complete
     if let Err(e) = runtime.block_on(monitoring_handle) {
-        log::error!("Error in monitoring task: {:?}", e);
+        error!("Error in monitoring task: {:?}", e);
     }
 
     info!("Shutdown complete");

--- a/crates/collector/src/main.rs
+++ b/crates/collector/src/main.rs
@@ -208,17 +208,17 @@ impl PerfEventProcessor {
         };
 
         // Timer migration detected - this is a critical error that invalidates measurements
-        error!("CRITICAL ERROR: Timer migration detected!");
         error!(
-            "Expected CPU: {}, Actual CPU: {}",
+            r#"CRITICAL ERROR: Timer migration detected!
+Expected CPU: {}, Actual CPU: {}
+Timer pinning failed - measurements are no longer reliable.
+This indicates either:
+  1. Kernel version doesn't support BPF timer CPU pinning (requires 6.7+)
+  2. Legacy fallback timer migration control failed
+  This case should never happen, please report this as a bug with the distribution and kernel version.
+Exiting to prevent incorrect performance measurements."#,
             event.expected_cpu, event.actual_cpu
         );
-        error!("Timer pinning failed - measurements are no longer reliable.");
-        error!("This indicates either:");
-        error!("  1. Kernel version doesn't support BPF timer CPU pinning (requires 6.7+)");
-        error!("  2. Legacy fallback timer migration control failed");
-        error!("This case should never happen, please report this as a bug with the distribution and kernel version.");
-        error!("Exiting to prevent incorrect performance measurements.");
 
         std::process::exit(1);
     }


### PR DESCRIPTION
This patch converts all outstanding use of `println!` and `eprintln!` macros in the `collector` crate to `debug!`/`info!`/`error!` from the `log` crate. It also changes some `info!`s to `debug!`s based on these requirements from the issue:

```
Most initialization and setup messages should use debug!
Only key information (like successful start confirmation) should use info!
``` 

Implements part of the work required for #173 