### PR TITLE
fix(collector): reduce time window for non-monotonicity, add timing grace window

### DIFF
--- a/crates/bpf/src/lib.rs
+++ b/crates/bpf/src/lib.rs
@@ -51,6 +51,7 @@ pub struct BpfLoader {
     skel: bpf::CollectorSkel<'static>,
     dispatcher: Dispatcher,
     perf_map_reader: PerfMapReader,
+    perf_timing_grace_ns: u64,
 }
 
 impl BpfLoader {
@@ -123,6 +124,7 @@ impl BpfLoader {
             skel,
             dispatcher,
             perf_map_reader,
+            perf_timing_grace_ns: 100_000, // 100 microseconds grace period for timing
         })
     }
 
@@ -177,11 +179,16 @@ impl BpfLoader {
         // Start a read batch
         reader_mut.start()?;
 
-        // Get current monotonic time in nanoseconds as the cutoff
+        // Get current monotonic time in nanoseconds
         let now_ns = now_monotonic_ns();
 
-        // Dispatch events until current time
-        self.dispatcher.dispatch_until(reader_mut, now_ns)?;
+        // Dispatch events until current time less than grace period
+        // be extra careful not to underflow when computing cutoff (such underflow should be extremely unlikely)
+        if now_ns > self.perf_timing_grace_ns {
+            // Compute cutoff
+            let cutoff_ns = now_ns - self.perf_timing_grace_ns;
+            self.dispatcher.dispatch_until(reader_mut, cutoff_ns)?;
+        }
 
         // Finish the read batch
         reader_mut.finish()?;

--- a/crates/perf_events/src/dispatcher.rs
+++ b/crates/perf_events/src/dispatcher.rs
@@ -159,7 +159,11 @@ impl Dispatcher {
     }
 
     /// Dispatches events until the reader is empty or the next event timestamp is >= until_timestamp_ns
-    pub fn dispatch_until(&mut self, reader: &mut Reader, until_timestamp_ns: u64) -> Result<(), DispatchError> {
+    pub fn dispatch_until(
+        &mut self,
+        reader: &mut Reader,
+        until_timestamp_ns: u64,
+    ) -> Result<(), DispatchError> {
         while !reader.is_empty() {
             // Check if the next event's timestamp is past our cutoff
             let timestamp = reader.peek_timestamp()?;


### PR DESCRIPTION
When message timestamps are collected a lot in advance of sending the message, userspace can decide to process a message that will be later (because it will see that message first).

1. move the timestamp computation as close as we could to sending the perf measurement so the race window is reduced

2. add an explicit grace period before current time, where userspace will not read messages  that are closer than that period, in case a message took that long to send. If all messages take less than the grace period to send, they will be processed in order.