### PR TITLE
fix(ci): check the result of ec2-github-runner, fail when appropriate

### DIFF
--- a/.github/actions/aws-runner/action.yml
+++ b/.github/actions/aws-runner/action.yml
@@ -236,13 +236,19 @@ runs:
       id: runner-outputs
       shell: bash
       run: |
-        # Pass through the runner outputs
+        # Always pass through the runner outputs (even if empty on failure)
         echo "label=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
         echo "ec2-instance-id=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
         echo "region=${{ steps.start-ec2-runner.outputs.region }}" >> $GITHUB_OUTPUT
-        if [ -n "${{ steps.start-ec2-runner.outputs.label }}" ]; then
+        
+        # Check if the ec2-runner step failed and exit at the end
+        if [ "${{ steps.start-ec2-runner.outcome }}" != "success" ]; then
+          echo "EC2 runner step failed with outcome: ${{ steps.start-ec2-runner.outcome }}"
+          echo "All runner attempts failed. Please check AWS capacity availability across regions."
+          exit 1
+        elif [ -n "${{ steps.start-ec2-runner.outputs.label }}" ]; then
           echo "Runner successfully started in region: ${{ steps.start-ec2-runner.outputs.region }}"
         else
-          echo "All runner attempts failed. Please check AWS capacity availability across regions."
+          echo "EC2 runner step succeeded but no runner label was returned"
           exit 1
         fi 


### PR DESCRIPTION
before this, when ec2-github-runner fails, the action still succeeds. Cleanup then has to wait for manual cancellation or until the 24 hour GitHub timeout fires for failing to schedule the jobs on the self hosted runner.

This might happen when the EC2 instance wasn't able to register its runner with GitHub (for example, if there were network issues fetching the runner).

After this, the action fails, so cleanup can happen immediately.