### PR TITLE
add resctrl crate

### DIFF
--- a/.github/workflows/test-resctrl-e2e.yaml
+++ b/.github/workflows/test-resctrl-e2e.yaml
@@ -131,8 +131,16 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          test -x ./resctrl-smoke
-          RESCTRL_E2E=1 ./resctrl-smoke --nocapture
+          # Locate the downloaded binary (actions/download-artifact@v4 places under a subdir)
+          BIN=$(find . -type f -name 'resctrl-smoke' | head -n 1)
+          if [ -z "$BIN" ]; then
+            echo "resctrl-smoke binary not found in workspace" >&2
+            find . -maxdepth 3 -type f | sed 's/^/  /'
+            exit 1
+          fi
+          chmod +x "$BIN" || true
+          echo "Executing $BIN"
+          RESCTRL_E2E=1 "$BIN" --nocapture
 
   stop-runner:
     name: Stop EC2 runner

--- a/.github/workflows/test-resctrl-e2e.yaml
+++ b/.github/workflows/test-resctrl-e2e.yaml
@@ -67,7 +67,6 @@ jobs:
           ldd "$BIN" || true
           cp "$BIN" resctrl-smoke
           chmod +x resctrl-smoke
-          echo "bin=resctrl-smoke" >> $GITHUB_OUTPUT
 
       - name: Upload resctrl smoke binary
         uses: actions/upload-artifact@v4
@@ -97,7 +96,6 @@ jobs:
           instance-type: ${{ inputs.instance-type || 'm7i.metal-24xl' }}
           image-type: ${{ inputs.image-type || 'ubuntu-24.04' }}
           market-type: 'spot'
-          volume-size: '40'
 
   resctrl-e2e:
     name: Run resctrl smoke test
@@ -131,13 +129,7 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          # Locate the downloaded binary (actions/download-artifact@v4 places under a subdir)
-          BIN=$(find . -type f -name 'resctrl-smoke' | head -n 1)
-          if [ -z "$BIN" ]; then
-            echo "resctrl-smoke binary not found in workspace" >&2
-            find . -maxdepth 3 -type f | sed 's/^/  /'
-            exit 1
-          fi
+          BIN=./resctrl-smoke
           chmod +x "$BIN" || true
           echo "Executing $BIN"
           RESCTRL_E2E=1 "$BIN" --nocapture
@@ -158,4 +150,4 @@ jobs:
           ec2-instance-id: ${{ needs.setup-runner.outputs.ec2-instance-id }}
           github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ needs.setup-runner.outputs.region || secrets.AWS_REGION }}
+          aws-region: ${{ needs.setup-runner.outputs.region }}

--- a/.github/workflows/test-resctrl-e2e.yaml
+++ b/.github/workflows/test-resctrl-e2e.yaml
@@ -51,14 +51,29 @@ jobs:
       - name: Build test binaries (no-run)
         run: |
           source $HOME/.cargo/env
-          cargo test -p resctrl --release --no-run
+          # Build only the hardware smoke integration test binary
+          cargo test -p resctrl --test smoke_test --release --no-run
 
-      - name: Upload resctrl test binaries
+      - name: Collect smoke test binary
+        id: collect-bin
+        run: |
+          set -euxo pipefail
+          BIN=$(find target/release/deps -maxdepth 1 -type f -executable -name 'smoke_test-*' | head -n 1)
+          if [ -z "$BIN" ]; then
+            echo "Smoke test binary not found" >&2
+            exit 1
+          fi
+          file "$BIN" || true
+          ldd "$BIN" || true
+          cp "$BIN" resctrl-smoke
+          chmod +x resctrl-smoke
+          echo "bin=resctrl-smoke" >> $GITHUB_OUTPUT
+
+      - name: Upload resctrl smoke binary
         uses: actions/upload-artifact@v4
         with:
-          name: resctrl-tests
-          path: |
-            target/release/deps/*
+          name: resctrl-smoke-bin
+          path: resctrl-smoke
           if-no-files-found: error
 
   setup-runner:
@@ -106,28 +121,18 @@ jobs:
             mount -t resctrl resctrl /sys/fs/resctrl
           fi
 
-      - name: Download test binaries
+      - name: Download smoke binary
         uses: actions/download-artifact@v4
         with:
-          name: resctrl-tests
-          path: resctrl-tests
+          name: resctrl-smoke-bin
+          path: ./
 
-      - name: Run resctrl tests (hardware)
+      - name: Run resctrl smoke test (hardware)
         shell: bash
         run: |
           set -euxo pipefail
-          chmod -R +x resctrl-tests || true
-          # Execute all resctrl test binaries found in artifact
-          found=0
-          for bin in $(find resctrl-tests -maxdepth 1 -type f -executable \( -name "smoke_test-*" -o -name "resctrl-*" \)); do
-            echo "Running test binary: $bin"
-            RESCTRL_E2E=1 "$bin" --nocapture
-            found=1
-          done
-          if [ "$found" -eq 0 ]; then
-            echo "No test binaries found in artifact" >&2
-            exit 1
-          fi
+          test -x ./resctrl-smoke
+          RESCTRL_E2E=1 ./resctrl-smoke --nocapture
 
   stop-runner:
     name: Stop EC2 runner

--- a/.github/workflows/test-resctrl-e2e.yaml
+++ b/.github/workflows/test-resctrl-e2e.yaml
@@ -1,0 +1,109 @@
+name: test-resctrl-e2e
+
+on:
+  workflow_dispatch:
+    inputs:
+      instance-type:
+        description: 'EC2 instance type to use'
+        required: false
+        default: 'm7i.metal-24xl'
+        type: string
+      image-type:
+        description: 'Runner AMI image type'
+        required: false
+        default: 'ubuntu-24.04'
+        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - 'crates/resctrl/**'
+      - '.github/workflows/test-resctrl-e2e.yaml'
+      - 'Cargo.toml'
+
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+
+jobs:
+  setup-runner:
+    name: Start EC2 runner (resctrl-capable)
+    runs-on: ubuntu-latest
+    outputs:
+      runner-label: ${{ steps.start-runner.outputs.runner-label }}
+      ec2-instance-id: ${{ steps.start-runner.outputs.ec2-instance-id }}
+      region: ${{ steps.start-runner.outputs.region }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Start AWS Runner
+        id: start-runner
+        uses: ./.github/actions/aws-runner
+        with:
+          github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+          iam-role-name: github-actions-runner
+          instance-type: ${{ inputs.instance-type || 'm7i.metal-24xl' }}
+          image-type: ${{ inputs.image-type || 'ubuntu-24.04' }}
+          market-type: 'spot'
+          volume-size: '40'
+
+  resctrl-e2e:
+    name: Run resctrl smoke test
+    needs: [setup-runner]
+    runs-on: ${{ needs.setup-runner.outputs.runner-label }}
+    timeout-minutes: 20
+    env:
+      HOME: /root
+    steps:
+      - name: Prepare HOME
+        run: mkdir -p "$HOME"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          if ! command -v rustc >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          fi
+          echo "source $HOME/.cargo/env" >> $HOME/.profile
+          source $HOME/.cargo/env
+          rustc -V
+          cargo -V
+
+      - name: Ensure resctrl is mounted
+        shell: bash
+        run: |
+          set -euxo pipefail
+          if ! grep -q "/sys/fs/resctrl" /proc/mounts; then
+            mount -t resctrl resctrl /sys/fs/resctrl
+          fi
+
+      - name: Run resctrl tests (unit + integration)
+        shell: bash
+        run: |
+          source $HOME/.cargo/env
+          export RESCTRL_E2E=1
+          cargo test -p resctrl --release -- --nocapture
+
+  stop-runner:
+    name: Stop EC2 runner
+    needs: [setup-runner, resctrl-e2e]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Stop AWS Runner
+        uses: ./.github/actions/aws-runner/cleanup
+        with:
+          runner-label: ${{ needs.setup-runner.outputs.runner-label }}
+          ec2-instance-id: ${{ needs.setup-runner.outputs.ec2-instance-id }}
+          github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ needs.setup-runner.outputs.region || secrets.AWS_REGION }}

--- a/.github/workflows/test-resctrl-e2e.yaml
+++ b/.github/workflows/test-resctrl-e2e.yaml
@@ -27,6 +27,40 @@ permissions:
   actions: write
 
 jobs:
+  build-and-unit-test:
+    name: Build + unit tests (GH hosted)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustc -V || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "source $HOME/.cargo/env" >> $HOME/.profile
+          source $HOME/.cargo/env
+          rustc -V
+          cargo -V
+
+      - name: Run unit tests (no hardware)
+        run: |
+          source $HOME/.cargo/env
+          # RESCTRL_E2E not set, so smoke test is skipped
+          cargo test -p resctrl --release -- --nocapture
+
+      - name: Build test binaries (no-run)
+        run: |
+          source $HOME/.cargo/env
+          cargo test -p resctrl --release --no-run
+
+      - name: Upload resctrl test binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: resctrl-tests
+          path: |
+            target/release/deps/*
+          if-no-files-found: error
+
   setup-runner:
     name: Start EC2 runner (resctrl-capable)
     runs-on: ubuntu-latest
@@ -52,7 +86,7 @@ jobs:
 
   resctrl-e2e:
     name: Run resctrl smoke test
-    needs: [setup-runner]
+    needs: [build-and-unit-test, setup-runner]
     runs-on: ${{ needs.setup-runner.outputs.runner-label }}
     timeout-minutes: 20
     env:
@@ -64,17 +98,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        shell: bash
-        run: |
-          if ! command -v rustc >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          fi
-          echo "source $HOME/.cargo/env" >> $HOME/.profile
-          source $HOME/.cargo/env
-          rustc -V
-          cargo -V
-
       - name: Ensure resctrl is mounted
         shell: bash
         run: |
@@ -83,12 +106,28 @@ jobs:
             mount -t resctrl resctrl /sys/fs/resctrl
           fi
 
-      - name: Run resctrl tests (unit + integration)
+      - name: Download test binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: resctrl-tests
+          path: resctrl-tests
+
+      - name: Run resctrl tests (hardware)
         shell: bash
         run: |
-          source $HOME/.cargo/env
-          export RESCTRL_E2E=1
-          cargo test -p resctrl --release -- --nocapture
+          set -euxo pipefail
+          chmod -R +x resctrl-tests || true
+          # Execute all resctrl test binaries found in artifact
+          found=0
+          for bin in $(find resctrl-tests -maxdepth 1 -type f -executable \( -name "smoke_test-*" -o -name "resctrl-*" \)); do
+            echo "Running test binary: $bin"
+            RESCTRL_E2E=1 "$bin" --nocapture
+            found=1
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No test binaries found in artifact" >&2
+            exit 1
+          fi
 
   stop-runner:
     name: Stop EC2 runner

--- a/.github/workflows/test-resctrl.yaml
+++ b/.github/workflows/test-resctrl.yaml
@@ -1,4 +1,4 @@
-name: test-resctrl-e2e
+name: test-resctrl
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ on:
       - main
     paths:
       - 'crates/resctrl/**'
-      - '.github/workflows/test-resctrl-e2e.yaml'
+      - '.github/workflows/test-resctrl.yaml'
       - 'Cargo.toml'
 
 permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,6 +2875,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "resctrl"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "tempfile",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/nri",
     "crates/trace-analysis",
     "crates/nri-init",
+    "crates/resctrl",
 ]
 
 [workspace.dependencies]

--- a/crates/resctrl/Cargo.toml
+++ b/crates/resctrl/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "resctrl"
+version = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+thiserror = { workspace = true }
+libc = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+anyhow = { workspace = true }
+uuid = { workspace = true }

--- a/crates/resctrl/README.md
+++ b/crates/resctrl/README.md
@@ -1,0 +1,40 @@
+resctrl crate
+
+Summary
+- Safe, testable wrapper over Linux resctrl filesystem for:
+  - create_group(pod_uid)
+  - delete_group(group_path)
+  - assign_tasks(group_path, pids) -> AssignmentResult
+  - list_group_tasks(group_path)
+
+API Overview
+- Construct with defaults:
+  - root: /sys/fs/resctrl
+  - group_prefix: "pod_"
+
+Example
+```rust
+use resctrl::{Resctrl, AssignmentResult};
+
+let res = Resctrl::default();
+let group = res.create_group("abc-123").expect("create group");
+let result: AssignmentResult = res.assign_tasks(&group, &[1234, 5678])?;
+let tasks = res.list_group_tasks(&group)?;
+res.delete_group(&group)?;
+```
+
+Errors
+- NotMounted: resctrl root is missing when creating groups
+- NoPermission: permission denied for mkdir/read/write/remove
+- Capacity: ENOSPC from kernel (e.g., RMID exhaustion)
+- Io: other io errors with path context
+
+Notes
+- Pod UID is sanitized to [a-zA-Z0-9_-] and truncated (<64) before prefixing.
+- Filesystem access goes through a trait to enable mocking in tests.
+
+Hardware smoke test
+- Integration test `tests/smoke_test.rs` is gated by `RESCTRL_E2E=1` and will:
+  - mount resctrl if needed
+  - create a group, assign current PID, verify, detach, delete
+- Run with: `RESCTRL_E2E=1 cargo test -p resctrl -- --nocapture`

--- a/crates/resctrl/src/error.rs
+++ b/crates/resctrl/src/error.rs
@@ -1,0 +1,20 @@
+use std::io;
+use std::path::PathBuf;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("resctrl not mounted at {root}")]
+    NotMounted { root: PathBuf },
+
+    #[error("permission denied for {path}: {source}")]
+    NoPermission { path: PathBuf, source: io::Error },
+
+    #[error("resctrl capacity exhausted: {source}")]
+    Capacity { source: io::Error },
+
+    #[error("io error at {path}: {source}")]
+    Io { path: PathBuf, source: io::Error },
+}
+

--- a/crates/resctrl/src/lib.rs
+++ b/crates/resctrl/src/lib.rs
@@ -1,0 +1,478 @@
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub use error::{Error, Result};
+
+mod error;
+mod provider;
+pub use provider::{FsProvider, RealFs};
+
+const DEFAULT_ROOT: &str = "/sys/fs/resctrl";
+const DEFAULT_PREFIX: &str = "pod_";
+const MAX_UID_LEN: usize = 63; // limit UID segment (<64)
+
+#[derive(Clone, Debug)]
+pub struct AssignmentResult {
+    pub assigned: usize,
+    pub missing: usize,
+}
+
+impl AssignmentResult {
+    pub fn new(assigned: usize, missing: usize) -> Self {
+        Self { assigned, missing }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub root: PathBuf,
+    pub group_prefix: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            root: PathBuf::from(DEFAULT_ROOT),
+            group_prefix: DEFAULT_PREFIX.to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Resctrl<P: FsProvider = RealFs> {
+    fs: P,
+    cfg: Config,
+}
+
+impl Default for Resctrl<RealFs> {
+    fn default() -> Self {
+        Self::new(Config::default())
+    }
+}
+
+impl Resctrl<RealFs> {
+    pub fn new(cfg: Config) -> Self {
+        Self { fs: RealFs, cfg }
+    }
+}
+
+impl<P: FsProvider> fmt::Debug for Resctrl<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Resctrl")
+            .field("root", &self.cfg.root)
+            .field("group_prefix", &self.cfg.group_prefix)
+            .finish()
+    }
+}
+
+impl<P: FsProvider> Resctrl<P> {
+    pub fn with_provider(fs: P, cfg: Config) -> Self {
+        Self { fs, cfg }
+    }
+
+    // Public API
+
+    pub fn create_group(&self, pod_uid: &str) -> Result<String> {
+        // Ensure root exists
+        if !self.fs.exists(&self.cfg.root) {
+            return Err(Error::NotMounted {
+                root: self.cfg.root.clone(),
+            });
+        }
+
+        let group_name = group_name(&self.cfg.group_prefix, pod_uid);
+        let path = self.cfg.root.join(&group_name);
+
+        match self.fs.create_dir(&path) {
+            Ok(()) => Ok(path.to_string_lossy().into_owned()),
+            Err(e) => match map_basic_fs_error(&path, &e) {
+                // Treat AlreadyExists as success (idempotent)
+                Error::Io { source, .. } if source.kind() == io::ErrorKind::AlreadyExists => {
+                    Ok(path.to_string_lossy().into_owned())
+                }
+                other => Err(other),
+            },
+        }
+    }
+
+    pub fn delete_group(&self, group_path: &str) -> Result<()> {
+        let p = PathBuf::from(group_path);
+        match self.fs.remove_dir(&p) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                if let Some(code) = e.raw_os_error() {
+                    if code == libc::ENOENT {
+                        // Idempotent delete: missing group is fine
+                        return Ok(());
+                    }
+                }
+                Err(map_basic_fs_error(&p, &e))
+            }
+        }
+    }
+
+    pub fn assign_tasks(&self, group_path: &str, pids: &[i32]) -> Result<AssignmentResult> {
+        let tasks_path = PathBuf::from(group_path).join("tasks");
+        let mut assigned = 0usize;
+        let mut missing = 0usize;
+
+        for pid in pids {
+            let s = pid.to_string();
+            match self.fs.write_str(&tasks_path, &s) {
+                Ok(()) => assigned += 1,
+                Err(e) => {
+                    // Classify errors
+                    if let Some(code) = e.raw_os_error() {
+                        match code {
+                            // ESRCH: task does not exist anymore → count as missing
+                            libc::ESRCH => {
+                                missing += 1;
+                                continue;
+                            }
+                            libc::EACCES | libc::EPERM => {
+                                return Err(Error::NoPermission {
+                                    path: tasks_path.clone(),
+                                    source: e,
+                                });
+                            }
+                            libc::ENOSPC => {
+                                return Err(Error::Capacity { source: e });
+                            }
+                            libc::ENOENT => {
+                                // Group/tasks file missing
+                                return Err(Error::Io {
+                                    path: tasks_path.clone(),
+                                    source: e,
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
+                    // Default: bubble as Io for tasks path
+                    return Err(Error::Io {
+                        path: tasks_path.clone(),
+                        source: e,
+                    });
+                }
+            }
+        }
+
+        Ok(AssignmentResult { assigned, missing })
+    }
+
+    pub fn list_group_tasks(&self, group_path: &str) -> Result<Vec<i32>> {
+        let tasks_path = PathBuf::from(group_path).join("tasks");
+        let s = self
+            .fs
+            .read_to_string(&tasks_path)
+            .map_err(|e| map_basic_fs_error(&tasks_path, &e))?;
+
+        let mut pids = Vec::new();
+        for line in s.lines() {
+            if let Ok(pid) = line.trim().parse::<i32>() {
+                pids.push(pid);
+            }
+        }
+        Ok(pids)
+    }
+}
+
+fn sanitize_uid(uid: &str) -> String {
+    let filtered: String = uid
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
+    let trimmed = if filtered.len() > MAX_UID_LEN {
+        filtered[..MAX_UID_LEN].to_string()
+    } else {
+        filtered
+    };
+    if trimmed.is_empty() {
+        "unknown".to_string()
+    } else {
+        trimmed
+    }
+}
+
+fn group_name(prefix: &str, pod_uid: &str) -> String {
+    format!("{}{}", prefix, sanitize_uid(pod_uid))
+}
+
+fn map_basic_fs_error(path: &Path, e: &io::Error) -> Error {
+    if let Some(code) = e.raw_os_error() {
+        match code {
+            libc::EACCES | libc::EPERM => Error::NoPermission {
+                path: path.to_path_buf(),
+                source: io::Error::from_raw_os_error(code),
+            },
+            libc::ENOSPC => Error::Capacity {
+                source: io::Error::from_raw_os_error(code),
+            },
+            _ => Error::Io {
+                path: path.to_path_buf(),
+                source: io::Error::from_raw_os_error(code),
+            },
+        }
+    } else {
+        Error::Io {
+            path: path.to_path_buf(),
+            source: io::Error::new(e.kind(), format!("{}", e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+    #[derive(Clone, Default)]
+    struct MockFs {
+        dirs: BTreeSet<PathBuf>,
+        files: BTreeMap<PathBuf, String>,
+        no_perm_files: HashSet<PathBuf>,
+        no_perm_dirs: HashSet<PathBuf>,
+        nospace_dirs: HashSet<PathBuf>,
+        missing_pids: HashSet<i32>,
+    }
+
+    impl MockFs {
+        fn add_dir(&mut self, p: &Path) {
+            self.dirs.insert(p.to_path_buf());
+        }
+        fn add_file(&mut self, p: &Path, content: &str) {
+            self.files.insert(p.to_path_buf(), content.to_string());
+        }
+        fn set_no_perm_file(&mut self, p: &Path) {
+            self.no_perm_files.insert(p.to_path_buf());
+        }
+        fn set_no_perm_dir(&mut self, p: &Path) {
+            self.no_perm_dirs.insert(p.to_path_buf());
+        }
+        fn set_nospace_dir(&mut self, p: &Path) {
+            self.nospace_dirs.insert(p.to_path_buf());
+        }
+        fn set_missing_pid(&mut self, pid: i32) {
+            self.missing_pids.insert(pid);
+        }
+    }
+
+    impl FsProvider for MockFs {
+        fn exists(&self, p: &Path) -> bool {
+            self.dirs.contains(p) || self.files.contains_key(p)
+        }
+        fn create_dir(&self, p: &Path) -> io::Result<()> {
+            if self.no_perm_dirs.contains(p) {
+                return Err(io::Error::from_raw_os_error(libc::EACCES));
+            }
+            if self.nospace_dirs.contains(p) {
+                return Err(io::Error::from_raw_os_error(libc::ENOSPC));
+            }
+            if self.dirs.contains(p) {
+                return Err(io::Error::new(io::ErrorKind::AlreadyExists, "exists"));
+            }
+            // Emulate mkdir success by adding to dirs
+            let mut me = self.clone();
+            let _ = me.dirs.insert(p.to_path_buf());
+            Ok(())
+        }
+        fn remove_dir(&self, p: &Path) -> io::Result<()> {
+            if self.no_perm_dirs.contains(p) {
+                return Err(io::Error::from_raw_os_error(libc::EACCES));
+            }
+            if !self.dirs.contains(p) {
+                return Err(io::Error::from_raw_os_error(libc::ENOENT));
+            }
+            Ok(())
+        }
+        fn write_str(&self, p: &Path, data: &str) -> io::Result<()> {
+            if self.no_perm_files.contains(p) {
+                return Err(io::Error::from_raw_os_error(libc::EACCES));
+            }
+            if !self.files.contains_key(p) {
+                return Err(io::Error::from_raw_os_error(libc::ENOENT));
+            }
+            // If writing to tasks, simulate ESRCH for missing pid
+            if p.ends_with("tasks") {
+                if let Ok(pid) = data.trim().parse::<i32>() {
+                    if self.missing_pids.contains(&pid) {
+                        return Err(io::Error::from_raw_os_error(libc::ESRCH));
+                    }
+                }
+                // Append pid to file content with newline
+                let mut me = self.clone();
+                let entry = me.files.entry(p.to_path_buf()).or_default();
+                if !entry.ends_with('\n') && !entry.is_empty() {
+                    entry.push('\n');
+                }
+                entry.push_str(data);
+                entry.push('\n');
+            }
+            Ok(())
+        }
+        fn read_to_string(&self, p: &Path) -> io::Result<String> {
+            if self.no_perm_files.contains(p) {
+                return Err(io::Error::from_raw_os_error(libc::EACCES));
+            }
+            match self.files.get(p) {
+                Some(s) => Ok(s.clone()),
+                None => Err(io::Error::from_raw_os_error(libc::ENOENT)),
+            }
+        }
+    }
+
+    #[test]
+    fn test_group_sanitization() {
+        let s = sanitize_uid("abcDEF-123_+=!:@#$%^&*()");
+        assert_eq!(s, "abcDEF-123_");
+
+        let long = "x".repeat(100);
+        let s2 = sanitize_uid(&long);
+        assert_eq!(s2.len(), MAX_UID_LEN);
+    }
+
+    #[test]
+    fn test_create_group_success() {
+        let mut fs = MockFs::default();
+        let root = PathBuf::from("/sys/fs/resctrl");
+        fs.add_dir(&root);
+        let cfg = Config { root: root.clone(), group_prefix: "pod_".into() };
+        let rc = Resctrl::with_provider(fs.clone(), cfg);
+        let group = rc.create_group("my-pod:UID").expect("create ok");
+        assert!(group.contains("/sys/fs/resctrl/pod_my-podUID"));
+    }
+
+    #[test]
+    fn test_create_group_not_mounted() {
+        let fs = MockFs::default();
+        let rc = Resctrl::with_provider(fs, Config::default());
+        let err = rc.create_group("uid").unwrap_err();
+        match err {
+            Error::NotMounted { .. } => {}
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_create_group_enospc_maps_capacity() {
+        let mut fs = MockFs::default();
+        let root = PathBuf::from("/sys/fs/resctrl");
+        fs.add_dir(&root);
+        let cfg = Config { root: root.clone(), group_prefix: "pod_".into() };
+        let group_path = root.join("pod_abc");
+        fs.set_nospace_dir(&group_path);
+
+        let rc = Resctrl::with_provider(fs, cfg);
+        let err = rc.create_group("abc").unwrap_err();
+        matches_capacity(err);
+    }
+
+    #[test]
+    fn test_delete_group_success() {
+        let mut fs = MockFs::default();
+        let root = PathBuf::from("/sys/fs/resctrl");
+        fs.add_dir(&root);
+        let group_path = root.join("pod_abc");
+        fs.add_dir(&group_path);
+
+        let rc = Resctrl::with_provider(fs, Config { root, group_prefix: "pod_".into() });
+        rc.delete_group(group_path.to_str().unwrap()).expect("delete ok");
+    }
+
+    #[test]
+    fn test_assign_tasks_success_and_missing() {
+        let mut fs = MockFs::default();
+        let root = PathBuf::from("/sys/fs/resctrl");
+        fs.add_dir(&root);
+        let group_path = root.join("pod_abc");
+        fs.add_dir(&group_path);
+        let tasks = group_path.join("tasks");
+        fs.add_file(&tasks, "");
+        fs.set_missing_pid(42);
+
+        let rc = Resctrl::with_provider(fs, Config { root, group_prefix: "pod_".into() });
+        let res = rc.assign_tasks(group_path.to_str().unwrap(), &[1, 42, 2]).expect("assign ok");
+        assert_eq!(res.assigned, 2);
+        assert_eq!(res.missing, 1);
+    }
+
+    #[test]
+    fn test_assign_tasks_no_permission() {
+        let mut fs = MockFs::default();
+        let root = PathBuf::from("/sys/fs/resctrl");
+        fs.add_dir(&root);
+        let group_path = root.join("pod_abc");
+        fs.add_dir(&group_path);
+        let tasks = group_path.join("tasks");
+        fs.add_file(&tasks, "");
+        fs.set_no_perm_file(&tasks);
+
+        let rc = Resctrl::with_provider(fs, Config { root, group_prefix: "pod_".into() });
+        let err = rc.assign_tasks(group_path.to_str().unwrap(), &[1]).unwrap_err();
+        match err {
+            Error::NoPermission { .. } => {}
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_assign_tasks_enoent_group_missing() {
+        let mut fs = MockFs::default();
+        let root = PathBuf::from("/sys/fs/resctrl");
+        fs.add_dir(&root);
+        let group_path = root.join("pod_abc");
+        fs.add_dir(&group_path);
+        // Do NOT create tasks file
+        let rc = Resctrl::with_provider(fs, Config { root, group_prefix: "pod_".into() });
+        let err = rc.assign_tasks(group_path.to_str().unwrap(), &[1]).unwrap_err();
+        match err {
+            Error::Io { path, source } => {
+                assert!(path.ends_with("tasks"));
+                assert_eq!(source.raw_os_error(), Some(libc::ENOENT));
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_list_group_tasks_success() {
+        let mut fs = MockFs::default();
+        let root = PathBuf::from("/sys/fs/resctrl");
+        fs.add_dir(&root);
+        let group_path = root.join("pod_abc");
+        fs.add_dir(&group_path);
+        let tasks = group_path.join("tasks");
+        fs.add_file(&tasks, "1\n2\nabc\n3\n");
+
+        let rc = Resctrl::with_provider(fs, Config { root, group_prefix: "pod_".into() });
+        let pids = rc.list_group_tasks(group_path.to_str().unwrap()).expect("list ok");
+        assert_eq!(pids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_list_group_tasks_no_permission() {
+        let mut fs = MockFs::default();
+        let root = PathBuf::from("/sys/fs/resctrl");
+        fs.add_dir(&root);
+        let group_path = root.join("pod_abc");
+        fs.add_dir(&group_path);
+        let tasks = group_path.join("tasks");
+        fs.add_file(&tasks, "");
+        fs.set_no_perm_file(&tasks);
+
+        let rc = Resctrl::with_provider(fs, Config { root, group_prefix: "pod_".into() });
+        let err = rc.list_group_tasks(group_path.to_str().unwrap()).unwrap_err();
+        match err {
+            Error::NoPermission { .. } => {}
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    fn matches_capacity(err: Error) {
+        match err {
+            Error::Capacity { .. } => {}
+            other => panic!("expected capacity, got {:?}", other),
+        }
+    }
+}

--- a/crates/resctrl/src/provider.rs
+++ b/crates/resctrl/src/provider.rs
@@ -1,0 +1,39 @@
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+
+pub trait FsProvider: Clone + Send + Sync + 'static {
+    fn exists(&self, p: &Path) -> bool;
+    fn create_dir(&self, p: &Path) -> io::Result<()>;
+    fn remove_dir(&self, p: &Path) -> io::Result<()>;
+    fn write_str(&self, p: &Path, data: &str) -> io::Result<()>;
+    fn read_to_string(&self, p: &Path) -> io::Result<String>;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RealFs;
+
+impl FsProvider for RealFs {
+    fn exists(&self, p: &Path) -> bool {
+        p.exists()
+    }
+
+    fn create_dir(&self, p: &Path) -> io::Result<()> {
+        fs::create_dir(p)
+    }
+
+    fn remove_dir(&self, p: &Path) -> io::Result<()> {
+        fs::remove_dir(p)
+    }
+
+    fn write_str(&self, p: &Path, data: &str) -> io::Result<()> {
+        // For resctrl tasks, the file must exist; do not create.
+        let mut f = OpenOptions::new().write(true).open(p)?;
+        f.write_all(data.as_bytes())
+    }
+
+    fn read_to_string(&self, p: &Path) -> io::Result<String> {
+        fs::read_to_string(p)
+    }
+}
+

--- a/crates/resctrl/tests/smoke_test.rs
+++ b/crates/resctrl/tests/smoke_test.rs
@@ -1,0 +1,72 @@
+use resctrl::{AssignmentResult, Resctrl};
+use std::process::Command;
+
+fn try_mount_resctrl() -> std::io::Result<()> {
+    // Attempt to mount the resctrl filesystem if not mounted
+    let status = Command::new("mount")
+        .args(["-t", "resctrl", "resctrl", "/sys/fs/resctrl"])
+        .status()?;
+    if status.success() {
+        return Ok(());
+    }
+    let out = Command::new("mount")
+        .arg("-v")
+        .args(["-t", "resctrl", "resctrl", "/sys/fs/resctrl"])
+        .output()?;
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if stderr.to_lowercase().contains("busy") || stderr.to_lowercase().contains("mounted") {
+        return Ok(());
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        format!("mount resctrl failed: status {:?}, err: {}", status.code(), stderr),
+    ))
+}
+
+#[test]
+fn resctrl_smoke() -> anyhow::Result<()> {
+    // Only run on explicit opt-in (hardware E2E). Otherwise skip to keep CI/dev fast.
+    if std::env::var("RESCTRL_E2E").ok().as_deref() != Some("1") {
+        eprintln!("RESCTRL_E2E not set; skipping hardware smoke test");
+        return Ok(());
+    }
+
+    let rc = Resctrl::default();
+    let uid = format!("smoke_{}", uuid::Uuid::new_v4());
+
+    let group = match rc.create_group(&uid) {
+        Ok(p) => p,
+        Err(resctrl::Error::NotMounted { .. }) => {
+            try_mount_resctrl()?;
+            let rc2 = Resctrl::default();
+            rc2.create_group(&uid)?
+        }
+        Err(e) => return Err(anyhow::anyhow!("create_group failed: {e}")),
+    };
+
+    let pid = std::process::id() as i32;
+    let AssignmentResult { assigned, missing } = rc.assign_tasks(&group, &[pid])?;
+    if assigned != 1 || missing != 0 {
+        return Err(anyhow::anyhow!(
+            "unexpected assignment result: assigned={}, missing={}",
+            assigned, missing
+        ));
+    }
+
+    let tasks = rc.list_group_tasks(&group)?;
+    if !tasks.iter().any(|p| *p == pid) {
+        return Err(anyhow::anyhow!(
+            "pid {} not found in group task list: {:?}",
+            pid, tasks
+        ));
+    }
+
+    // Detach and cleanup
+    let AssignmentResult { assigned, .. } = rc.assign_tasks("/sys/fs/resctrl", &[pid])?;
+    if assigned != 1 {
+        eprintln!("warning: could not detach pid {} back to root (assigned={})", pid, assigned);
+    }
+    rc.delete_group(&group)?;
+    Ok(())
+}
+


### PR DESCRIPTION
Summary
- Add new resctrl crate with safe APIs (create/delete groups, assign/list tasks) and domain error model (NotMounted, NoPermission, Capacity, Io) behind FsProvider abstraction.
- Add integration smoke test (tests/smoke_test.rs) gated by RESCTRL_E2E=1 for hardware runs; unit tests use a mock filesystem provider.
- Add GitHub Actions workflow (test-resctrl.yaml):
  - Build + unit tests on GitHub-hosted runner; build only the resctrl smoke test binary and upload it as artifact.
  - Provision m7i.metal-24xl spot EC2 runner via existing aws-runner composite action and run the smoke binary there (mounts resctrl if needed).
- Triggers: manual (workflow_dispatch) and push to main on relevant paths (crates/resctrl/**, workflow file, workspace Cargo.toml).

Notes
- Uses existing secrets: REPO_ADMIN_TOKEN, AWS_ROLE_ARN.
- delete_group is idempotent when group is missing (ENOENT).

Testing
- cargo test -p resctrl (unit tests) on GH-hosted.
- End-to-end workflow verified green via gh run watch.