### PR TITLE
NRI: enrich timeslot metrics with container metadata (best‑effort)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.27.1",
+ "nri",
  "object_store",
  "parquet",
  "perf_events",

--- a/crates/collector/Cargo.toml
+++ b/crates/collector/Cargo.toml
@@ -32,6 +32,7 @@ futures = { workspace = true }
 chrono = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
+nri = { workspace = true }
 
 [dev-dependencies]
 testing_logger = "0.1"

--- a/crates/collector/src/timeslot_to_recordbatch_task.rs
+++ b/crates/collector/src/timeslot_to_recordbatch_task.rs
@@ -205,7 +205,7 @@ impl TimeslotToRecordBatchTask {
             tokio::select! {
                 // Process metadata messages when available
                 maybe_msg = async {
-                    if let Some(rx) = &mut self.metadata_receiver { rx.recv().await } else { pending().await }
+                    if let Some(rx) = &mut self.metadata_receiver { rx.recv().await } else { pending::<Option<MetadataMessage>>().await }
                 } => {
                     match maybe_msg {
                         Some(msg) => self.process_metadata_message(msg),


### PR DESCRIPTION
Implements unvariance/collector#251 (sub-issue of #153).

Summary
- Best‑effort NRI integration: auto-detect `/var/run/nri/nri.sock`, attempt to connect/register, warn and continue if unavailable.
- Map `cgroup_id` (inode) -> `ContainerMetadata` using NRI `MetadataMessage` stream and cgroup path `stat()` against cgroup v2 mount.
- Enrich timeslot `RecordBatch` rows with Kubernetes container context when available.
- Maintain bounded maps and cleanup on `MetadataMessage::Remove`.
- Single-threaded `tokio::select!` in the converter to process timeslots and metadata in-order.

Schema changes (timeslot)
- Added nullable fields after `cgroup_id`:
  - `pod_name` (Utf8)
  - `pod_namespace` (Utf8)
  - `pod_uid` (Utf8)
  - `container_name` (Utf8)
  - `container_id` (Utf8)

Code changes
- `crates/collector/src/timeslot_to_recordbatch_task.rs`
  - Extend schema, enrich rows, add mapping and cgroup path → inode resolver.
  - Accept optional NRI `mpsc::Receiver<MetadataMessage>`; merge via `tokio::select!`.
  - Tests updated to the new schema and indexes.
- `crates/collector/src/main.rs`
  - Best‑effort NRI init; monitors plugin server without affecting collector lifecycle.
  - Pass metadata channel to `TimeslotToRecordBatchTask`.
- `crates/collector/Cargo.toml`
  - Add `nri` dependency (workspace).

Notes
- No impact on eBPF code; enrichment joins with `TaskMetadata.cgroup_id`.
- Labels/annotations are not added yet; can be extended in follow‑ups if needed.
- Local macOS build will fail for eBPF deps; validated via unit tests structure. Please rely on Linux CI for full build.

Screenshots/Testing
- Unit tests for the converter updated to ensure correct column layout and null defaults w/o NRI.

