### PR TITLE
chore: format codebase

### DIFF
--- a/cmd/bpftracer/main.go
+++ b/cmd/bpftracer/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	// Set up stdout and stderr
 	cmd.Stdout = os.Stdout
-	cmd. Stderr = os.Stderr
+	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
 		fmt.Printf("Failed to start bpftrace: %v\n", err)
@@ -49,9 +49,9 @@ func main() {
 	// // Wait for a signal
 	// <-sig
 	// fmt.Println("Received signal, stopping bpftrace...")
-// 
+	//
 	// // Kill the bpftrace process
 	// if err := cmd.Process.Kill(); err != nil {
-		// fmt.Printf("Failed to kill bpftrace: %v\n", err)
+	// fmt.Printf("Failed to kill bpftrace: %v\n", err)
 	// }
 }

--- a/cmd/prometheus_metrics/collector_test.go
+++ b/cmd/prometheus_metrics/collector_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 func TestMetricsUp(t *testing.T) {
 
 	// Initialize module/server for standalone integration test
@@ -38,9 +37,9 @@ func TestMetricsUp(t *testing.T) {
 
 		// Check current server metrics against expected string/value
 		if err := testutil.ScrapeAndCompare(serverURL+"/metrics", strings.NewReader(expected), metricName); err == nil {
-		    return true
+			return true
 
-		// Returns an error and error message if the expected string/value is not found
+			// Returns an error and error message if the expected string/value is not found
 		} else {
 			t.Log(err.Error())
 			return false

--- a/cmd/prometheus_metrics/main.go
+++ b/cmd/prometheus_metrics/main.go
@@ -1,15 +1,13 @@
 package main
 
 import (
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
-    "github.com/prometheus/client_golang/prometheus/promhttp"
 )
-
 
 func main() {
 	go recordMetrics()
-	
+
 	http.Handle("/metrics", promhttp.Handler())
 	http.ListenAndServe(":2112", nil)
 }
-

--- a/cmd/prometheus_metrics/record_metrics.go
+++ b/cmd/prometheus_metrics/record_metrics.go
@@ -4,15 +4,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-
 func recordMetrics() {
 	upMetric := prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: 	"perfpod",
-			Subsystem: 	"memory_collector",
-			Name: 		"up_metric",
-			Help: 		"Test metric to confirm skeleton application functionality.",
-		})
-		prometheus.MustRegister(upMetric)
-	
-		upMetric.Set(1)
+		Namespace: "perfpod",
+		Subsystem: "memory_collector",
+		Name:      "up_metric",
+		Help:      "Test metric to confirm skeleton application functionality.",
+	})
+	prometheus.MustRegister(upMetric)
+
+	upMetric.Set(1)
 }

--- a/crates/trace-analysis/src/analyzer.rs
+++ b/crates/trace-analysis/src/analyzer.rs
@@ -19,7 +19,7 @@ pub trait Analysis {
 
     /// Return the schema for the new columns this analysis adds
     fn new_columns_schema(&self) -> Vec<Arc<Field>>;
-    
+
     /// Called after all batches have been processed to finalize the analysis
     fn finalize(&self) -> Result<()> {
         Ok(())
@@ -96,10 +96,10 @@ impl Analyzer {
 
         progress_bar.close()?;
         writer.close().with_context(|| "Failed to close writer")?;
-        
+
         // Finalize the analysis
         analysis.finalize()?;
-        
+
         Ok(())
     }
 

--- a/crates/trace-analysis/src/main.rs
+++ b/crates/trace-analysis/src/main.rs
@@ -84,12 +84,22 @@ fn main() -> Result<()> {
         "concurrency" => {
             // Create concurrency analysis module
             let mut analysis = ConcurrencyAnalysis::new(num_cpus)?;
-            
+
             // Set CSV output paths
-            let total_csv_path = determine_csv_output_filename(&cli.filename, cli.output_prefix.as_deref(), "total_concurrency")?;
-            let same_process_csv_path = determine_csv_output_filename(&cli.filename, cli.output_prefix.as_deref(), "same_process_concurrency")?;
-            analysis.set_csv_paths(total_csv_path.to_string_lossy().to_string(), 
-                                  same_process_csv_path.to_string_lossy().to_string());
+            let total_csv_path = determine_csv_output_filename(
+                &cli.filename,
+                cli.output_prefix.as_deref(),
+                "total_concurrency",
+            )?;
+            let same_process_csv_path = determine_csv_output_filename(
+                &cli.filename,
+                cli.output_prefix.as_deref(),
+                "same_process_concurrency",
+            )?;
+            analysis.set_csv_paths(
+                total_csv_path.to_string_lossy().to_string(),
+                same_process_csv_path.to_string_lossy().to_string(),
+            );
 
             // Process the Parquet file
             analyzer.process_parquet_file(builder, analysis)?;
@@ -103,8 +113,11 @@ fn main() -> Result<()> {
         }
         "monotonicity" => {
             // Create CSV output filename for monotonicity analysis
-            let csv_output =
-                determine_csv_output_filename(&cli.filename, cli.output_prefix.as_deref(), "monotonicity_analysis")?;
+            let csv_output = determine_csv_output_filename(
+                &cli.filename,
+                cli.output_prefix.as_deref(),
+                "monotonicity_analysis",
+            )?;
 
             // Create monotonicity analysis module
             let analysis = MonotonicityAnalysis::new(csv_output)?;


### PR DESCRIPTION
Ran `cargo fmt --all` and `go fmt ./...` to apply standard formatting across the Rust workspace and Go modules.

No functional changes; formatting only.