### PR TITLE
ci: disable test-nri-init on pull_request

### DIFF
--- a/.github/workflows/test-nri-init.yaml
+++ b/.github/workflows/test-nri-init.yaml
@@ -3,8 +3,6 @@ name: test-nri-init
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This change disables the `test-nri-init` workflow on `pull_request` events to avoid permission-related failures from forks.

- Triggers kept: `push` to `main`, `workflow_dispatch`
- Removed: `pull_request`

No code changes; CI config only.