### PR TITLE
NRI: Enrich RecordBatches with container metadata and add e2e checks

### DIFF
--- a/.github/workflows/test-helm-chart.yaml
+++ b/.github/workflows/test-helm-chart.yaml
@@ -346,8 +346,12 @@ jobs:
             echo "Setting up aggregated mode field verification..."
             REQUIRED_FIELDS=("pid" "start_time" "cgroup_id" "cache_references" "cycles" "instructions" "llc_misses")
           fi
+
+          # NRI enrichment fields are expected in both modes (nullable)
+          ENRICH_FIELDS=("pod_name" "pod_namespace" "pod_uid" "container_name" "container_id")
+          REQUIRED_FIELDS+=("${ENRICH_FIELDS[@]}")
           
-          # Verify all required fields are present in schema
+          # Verify all required fields are present in schema (including NRI enrichment)
           echo "Verifying required fields in schema..."
           for field in "${REQUIRED_FIELDS[@]}"; do
             if ! grep -q "$field" schema.txt; then
@@ -389,6 +393,167 @@ jobs:
           done
           
           echo "Parquet file verification completed successfully for ${{ matrix.trace-mode == true && 'trace' || 'aggregated' }} mode"
+
+  nri-enrichment-e2e:
+    name: NRI Enrichment E2E
+    needs: [setup-runner]
+    runs-on: ${{ needs.setup-runner.outputs.runner-label }}
+    timeout-minutes: 20
+    env:
+      HOME: /root
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      POD_NAME: nri-enrichment-test
+      POD_NAMESPACE: default
+      EXPECTED_COMM: sleep
+      RELEASE_NAME: collector-nri-e2e
+    steps:
+      - name: Create HOME directory
+        run: mkdir -p $HOME
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Install K3s (recent version with NRI enabled by default)
+        run: |
+          curl -sfL https://get.k3s.io | sh
+          systemctl status k3s || true
+
+      - name: Wait for Kubernetes API
+        run: |
+          echo "Waiting for Kubernetes API..."
+          until kubectl get nodes &>/dev/null; do
+            sleep 1
+            echo "Still waiting..."
+          done
+          echo "Kubernetes API is available!"
+          kubectl wait --for=condition=Ready nodes --all --timeout=300s
+
+      - name: Install pqrs
+        run: |
+          curl -L -o pqrs.zip https://github.com/manojkarthick/pqrs/releases/download/v0.3.2/pqrs-0.3.2-x86_64-unknown-linux-gnu.zip
+          python3 -m zipfile -e pqrs.zip .
+          sudo mv pqrs-0.3.2-x86_64-unknown-linux-gnu/bin/pqrs /usr/local/bin/
+          sudo chmod +x /usr/local/bin/pqrs
+          rm -rf pqrs.zip pqrs-0.3.2-x86_64-unknown-linux-gnu
+          pqrs --version
+
+      - name: Deploy test pod (${POD_NAME})
+        run: |
+          cat > pod.yaml << EOF
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: ${POD_NAME}
+            namespace: ${POD_NAMESPACE}
+            labels:
+              app: nri-enrichment-test
+          spec:
+            restartPolicy: Never
+            containers:
+              - name: tester
+                image: busybox:1.36
+                command: ["sh", "-c", "sleep 600"]
+          EOF
+          kubectl apply -f pod.yaml
+          kubectl wait --for=condition=Ready pod/${POD_NAME} -n ${POD_NAMESPACE} --timeout=90s
+          kubectl get pod ${POD_NAME} -n ${POD_NAMESPACE} -o wide
+
+      - name: Deploy Collector (local storage)
+        run: |
+          # Use local chart and local storage; var-run is mounted by the chart to access NRI socket
+          cat > values-override.yaml << EOF
+          collector:
+            verbose: true
+            trace: false
+          storage:
+            type: "local"
+            prefix: "nri-e2e-"
+          EOF
+          helm upgrade --install ${RELEASE_NAME} ./charts/collector -f values-override.yaml
+          kubectl wait --for=condition=Ready pods --timeout=120s -l app.kubernetes.io/name=collector
+          kubectl get pods -l app.kubernetes.io/name=collector -o wide
+
+      - name: Let collector run and gather data
+        run: |
+          echo "Sleeping to allow metrics collection..."
+          sleep 20
+
+      - name: Flush and stop collector
+        run: |
+          COLLECTOR_POD=$(kubectl get pods -l app.kubernetes.io/name=collector -o jsonpath='{.items[0].metadata.name}')
+          echo "Collector pod: $COLLECTOR_POD"
+          # Trigger graceful shutdown to flush parquet
+          kubectl exec "$COLLECTOR_POD" -c collector -- /bin/sh -c "kill -INT 1" || true
+          sleep 5
+
+      - name: Copy parquet to host
+        run: |
+          COLLECTOR_POD=$(kubectl get pods -l app.kubernetes.io/name=collector -o jsonpath='{.items[0].metadata.name}')
+          echo "Collector pod: $COLLECTOR_POD"
+          echo "Listing files in /data:"
+          kubectl exec "$COLLECTOR_POD" -c collector -- ls -la /data || true
+          FILE=$(kubectl exec "$COLLECTOR_POD" -c collector -- /bin/sh -c "ls -1 /data/*.parquet 2>/dev/null | head -n1")
+          if [ -z "$FILE" ]; then
+            echo "No parquet file found in collector pod"
+            exit 1
+          fi
+          echo "Found parquet: $FILE"
+          kubectl cp "$COLLECTOR_POD:$FILE" /tmp/nri-e2e.parquet -c collector
+          ls -la /tmp/nri-e2e.parquet
+
+      - name: Verify enrichment fields and values
+        env:
+          PARQUET: /tmp/nri-e2e.parquet
+        run: |
+          echo "Schema:"
+          pqrs schema "$PARQUET"
+          # Verify fields exist
+          for f in pod_name pod_namespace pod_uid container_name container_id process_name cgroup_id; do
+            if ! pqrs schema "$PARQUET" | grep -q "$f"; then
+              echo "Missing expected field: $f"
+              exit 1
+            fi
+          done
+          # Filter rows for our pod
+          pqrs cat --json "$PARQUET" | jq -c "select(.pod_name==\"$POD_NAME\")" > /tmp/nri-rows.json || true
+          COUNT=$(wc -l < /tmp/nri-rows.json | tr -d ' ')
+          echo "Rows for pod $POD_NAME: $COUNT"
+          if [ "$COUNT" -lt 1 ]; then
+            echo "No rows found for pod $POD_NAME; enrichment likely failed"
+            exit 1
+          fi
+          # Verify container name matches
+          CNAMES=$(jq -r .container_name /tmp/nri-rows.json | sort -u | tr '\n' ' ')
+          echo "Container names: $CNAMES"
+          if ! echo "$CNAMES" | grep -qw "tester"; then
+            echo "Expected container_name 'tester' not found"
+            exit 1
+          fi
+          # Verify process name includes expected comm (sleep)
+          COMMS=$(jq -r .process_name /tmp/nri-rows.json | sort -u | tr '\n' ' ')
+          echo "Process names: $COMMS"
+          if ! echo "$COMMS" | grep -qw "$EXPECTED_COMM"; then
+            echo "Expected process_name '$EXPECTED_COMM' not found among: $COMMS"
+            exit 1
+          fi
+          # Verify namespace
+          NSES=$(jq -r .pod_namespace /tmp/nri-rows.json | sort -u | tr '\n' ' ')
+          echo "Namespaces: $NSES"
+          if ! echo "$NSES" | grep -qw "$POD_NAMESPACE"; then
+            echo "Expected pod_namespace '$POD_NAMESPACE' not found"
+            exit 1
+          fi
+          echo "✅ NRI enrichment verified for pod $POD_NAME"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          helm uninstall ${RELEASE_NAME} --wait --timeout=60s || true
+          kubectl delete pod ${POD_NAME} -n ${POD_NAMESPACE} --ignore-not-found
 
   stop-runner:
     name: Stop EC2 runner

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.27.1",
+ "nri",
  "object_store",
  "parquet",
  "perf_events",

--- a/charts/collector/templates/collector.yaml
+++ b/charts/collector/templates/collector.yaml
@@ -129,6 +129,8 @@ spec:
             - name: data-volume
               mountPath: /data
             {{- end }}
+            - name: var-run
+              mountPath: /var/run
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
             - name: sys-kernel-tracing

--- a/crates/collector/Cargo.toml
+++ b/crates/collector/Cargo.toml
@@ -32,6 +32,7 @@ futures = { workspace = true }
 chrono = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
+nri = { workspace = true }
 
 [dev-dependencies]
 testing_logger = "0.1"

--- a/crates/collector/src/nri_enrich_recordbatch_task.rs
+++ b/crates/collector/src/nri_enrich_recordbatch_task.rs
@@ -1,0 +1,545 @@
+use std::collections::HashMap;
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+use arrow_array::builder::StringBuilder;
+use arrow_array::{ArrayRef, Int64Array, RecordBatch};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use log::{debug, error, info, warn};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use nri::metadata::{ContainerMetadata, MetadataMessage, MetadataPlugin};
+use nri::NRI;
+
+/// Fields appended by the NRI enrichment task
+const ENRICH_FIELDS: &[(&str, DataType)] = &[
+    ("pod_name", DataType::Utf8),
+    ("pod_namespace", DataType::Utf8),
+    ("pod_uid", DataType::Utf8),
+    ("container_name", DataType::Utf8),
+    ("container_id", DataType::Utf8),
+];
+
+/// Resolve a cgroup2 mount point by scanning /proc/self/mountinfo
+fn find_cgroup2_mount_point() -> Result<PathBuf> {
+    let mount_info =
+        fs::read_to_string("/proc/self/mountinfo").context("Failed to read /proc/self/mountinfo")?;
+
+    for line in mount_info.lines() {
+        // mountinfo format:
+        // 33 30 0:29 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup2 rw
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 9 && parts[8].contains("cgroup2") {
+            // parts[4] is the mountpoint
+            let mount_point = parts[4].to_string();
+            return Ok(PathBuf::from(mount_point));
+        }
+    }
+
+    Err(anyhow!("Could not find cgroup2 mount point"))
+}
+
+/// Attempt to resolve a cgroup path to an inode number (cgroup id)
+///
+/// Handles:
+/// - Absolute cgroup paths (stat directly)
+/// - Paths relative to cgroup2 mountpoint (join accordingly)
+fn resolve_cgroup_inode(cgroup_path: &str) -> Result<u64> {
+    // First try as-is if it's an absolute path
+    let path = Path::new(cgroup_path);
+    if path.is_absolute() {
+        if let Ok(metadata) = fs::metadata(path) {
+            return Ok(metadata.ino());
+        }
+    }
+
+    // Otherwise, try to join with the cgroup2 mount point
+    let mount_point = find_cgroup2_mount_point()?;
+    let joined = if cgroup_path.starts_with('/') {
+        mount_point.join(&cgroup_path[1..])
+    } else {
+        mount_point.join(cgroup_path)
+    };
+
+    let metadata = fs::metadata(&joined)
+        .with_context(|| format!("Failed to get metadata for cgroup path: {:?}", joined))?;
+    Ok(metadata.ino())
+}
+
+/// Task that enriches incoming RecordBatches with container metadata based on cgroup_id
+pub struct NRIEnrichRecordBatchTask {
+    // IO
+    batch_receiver: mpsc::Receiver<RecordBatch>,
+    batch_sender: mpsc::Sender<RecordBatch>,
+
+    // Schemas
+    input_schema: SchemaRef,
+    output_schema: SchemaRef,
+
+    // NRI message channel
+    metadata_rx: mpsc::Receiver<MetadataMessage>,
+
+    // NRI runtime
+    nri: Option<NRI>,
+    nri_join_done: Option<tokio::sync::oneshot::Receiver<anyhow::Result<()>>>,
+
+    // Mapping structures
+    container_to_inode: HashMap<String, u64>,
+    inode_to_metadata: HashMap<u64, ContainerMetadata>,
+}
+
+impl NRIEnrichRecordBatchTask {
+    /// Create a new enrichment task with channels and input schema
+    pub fn new(
+        batch_receiver: mpsc::Receiver<RecordBatch>,
+        batch_sender: mpsc::Sender<RecordBatch>,
+        input_schema: SchemaRef,
+    ) -> Self {
+        // Build output schema (input + appended nullable columns)
+        let mut fields: Vec<Field> = input_schema.fields().iter().cloned().collect();
+        for (name, dt) in ENRICH_FIELDS {
+            fields.push(Field::new(name, dt.clone(), true));
+        }
+        let output_schema = Arc::new(Schema::new(fields));
+
+        // Create metadata channel for NRI plugin
+        let (_tx, rx) = mpsc::channel::<MetadataMessage>(1000);
+
+        Self {
+            batch_receiver,
+            batch_sender,
+            input_schema,
+            output_schema,
+            metadata_rx: rx,
+            nri: None,
+            nri_join_done: None,
+            container_to_inode: HashMap::new(),
+            inode_to_metadata: HashMap::new(),
+        }
+    }
+
+    /// Return the output schema (input + enrichment columns)
+    pub fn schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+
+    /// Initialize NRI plugin and connection. Returns Ok if connected or best-effort disabled.
+    async fn init_nri(&mut self) -> Result<()> {
+        // Rebuild a fresh channel for metadata messages and plugin
+        let (tx, rx) = mpsc::channel::<MetadataMessage>(1000);
+        self.metadata_rx = rx;
+        let plugin = MetadataPlugin::new(tx);
+
+        // Determine socket path
+        let socket_path = std::env::var("NRI_SOCKET_PATH")
+            .unwrap_or_else(|_| "/var/run/nri/nri.sock".to_string());
+
+        // Try to connect
+        match tokio::net::UnixStream::connect(&socket_path).await {
+            Ok(stream) => {
+                info!("Connecting to NRI socket at {}", socket_path);
+                let (nri, join_handle) =
+                    NRI::new(stream, plugin, "collector-metadata", "10").await?;
+
+                // Register plugin
+                if let Err(e) = nri.register().await {
+                    warn!(
+                        "NRI registration failed (best-effort mode, continuing without enrichment): {}",
+                        e
+                    );
+                    return Ok(()); // Best-effort: remain without an active NRI
+                }
+
+                // Create a oneshot channel to receive join result
+                let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+                tokio::spawn(async move {
+                    let res = join_handle.await;
+                    let mapped = match res {
+                        Ok(inner) => inner,
+                        Err(join_err) => Err(anyhow!("NRI join error: {}", join_err)),
+                    };
+                    let _ = done_tx.send(mapped);
+                });
+
+                self.nri = Some(nri);
+                self.nri_join_done = Some(done_rx);
+                info!("NRI plugin registered successfully");
+            }
+            Err(e) => {
+                warn!(
+                    "NRI socket not available at {} (best-effort mode, continuing without enrichment): {}",
+                    socket_path, e
+                );
+                // Best-effort: keep nri as None; enrichment will produce nulls
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Process a single metadata message: update or remove mappings
+    fn process_metadata_message(&mut self, msg: MetadataMessage) {
+        match msg {
+            MetadataMessage::Add(container_id, metadata) => {
+                if metadata.cgroup_path.is_empty() {
+                    debug!(
+                        "Received metadata without cgroup_path for container {}, ignoring",
+                        container_id
+                    );
+                    return;
+                }
+                match resolve_cgroup_inode(&metadata.cgroup_path) {
+                    Ok(inode) => {
+                        // Update both maps
+                        self.container_to_inode.insert(container_id.clone(), inode);
+                        self.inode_to_metadata.insert(inode, metadata);
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to resolve cgroup inode for container {}: {}",
+                            container_id, e
+                        );
+                    }
+                }
+            }
+            MetadataMessage::Remove(container_id) => {
+                if let Some(inode) = self.container_to_inode.remove(&container_id) {
+                    self.inode_to_metadata.remove(&inode);
+                }
+            }
+        }
+    }
+
+    /// Enrich a RecordBatch by appending enrichment columns. Best-effort: nulls when missing.
+    fn enrich_batch(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+        // Find cgroup_id column index and ensure type is Int64
+        let cgroup_idx = batch
+            .schema()
+            .fields()
+            .iter()
+            .position(|f| f.name() == "cgroup_id")
+            .ok_or_else(|| anyhow!("cgroup_id column not found in input batch schema"))?;
+
+        let cgroup_array = batch.column(cgroup_idx);
+        let cgroup_ids = cgroup_array
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| anyhow!("cgroup_id column is not Int64"))?;
+
+        let num_rows = batch.num_rows();
+
+        // Builders for enrichment columns
+        let mut pod_name_b = StringBuilder::with_capacity(num_rows, num_rows * 16);
+        let mut pod_ns_b = StringBuilder::with_capacity(num_rows, num_rows * 16);
+        let mut pod_uid_b = StringBuilder::with_capacity(num_rows, num_rows * 16);
+        let mut container_name_b = StringBuilder::with_capacity(num_rows, num_rows * 16);
+        let mut container_id_b = StringBuilder::with_capacity(num_rows, num_rows * 16);
+
+        for i in 0..num_rows {
+            let inode = cgroup_ids.value(i) as u64;
+            if let Some(meta) = self.inode_to_metadata.get(&inode) {
+                pod_name_b.append_value(meta.pod_name.as_str());
+                pod_ns_b.append_value(meta.pod_namespace.as_str());
+                pod_uid_b.append_value(meta.pod_uid.as_str());
+                container_name_b.append_value(meta.container_name.as_str());
+                container_id_b.append_value(meta.container_id.as_str());
+            } else {
+                pod_name_b.append_null();
+                pod_ns_b.append_null();
+                pod_uid_b.append_null();
+                container_name_b.append_null();
+                container_id_b.append_null();
+            }
+        }
+
+        // Create new arrays vector: original columns + enrichment columns
+        let mut arrays: Vec<ArrayRef> = batch.columns().to_vec();
+        arrays.push(Arc::new(pod_name_b.finish()));
+        arrays.push(Arc::new(pod_ns_b.finish()));
+        arrays.push(Arc::new(pod_uid_b.finish()));
+        arrays.push(Arc::new(container_name_b.finish()));
+        arrays.push(Arc::new(container_id_b.finish()));
+
+        RecordBatch::try_new(self.output_schema.clone(), arrays)
+            .map_err(|e| anyhow!("Failed to create enriched RecordBatch: {}", e))
+    }
+
+    /// Run the enrichment task: read metadata and batches, output enriched batches
+    pub async fn run(mut self) -> Result<()> {
+        // Try initializing NRI (best-effort)
+        if let Err(e) = self.init_nri().await {
+            warn!(
+                "Failed to initialize NRI (best-effort mode, continuing without enrichment): {}",
+                e
+            );
+        }
+
+        loop {
+            tokio::select! {
+                // Handle input record batches
+                maybe_batch = self.batch_receiver.recv() => {
+                    match maybe_batch {
+                        Some(batch) => {
+                            match self.enrich_batch(&batch) {
+                                Ok(enriched) => {
+                                    if let Err(e) = self.batch_sender.send(enriched).await {
+                                        // Downstream closed - stop the task
+                                        debug!("Downstream batch channel closed: {}", e);
+                                        break;
+                                    }
+                                },
+                                Err(e) => {
+                                    // If enrichment fails due to schema issues, log and forward original batch
+                                    warn!("Failed to enrich batch (forwarding original): {}", e);
+                                    if let Err(e) = self.batch_sender.send(batch).await {
+                                        debug!("Downstream batch channel closed: {}", e);
+                                        break;
+                                    }
+                                }
+                            }
+                        },
+                        None => {
+                            // Input closed; shutdown NRI and exit
+                            debug!("Input batch channel closed, shutting down NRI enrichment task");
+                            if let Some(nri) = &self.nri {
+                                let _ = nri.close().await; // best-effort close
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                // Handle metadata messages to update mapping
+                maybe_msg = self.metadata_rx.recv() => {
+                    if let Some(msg) = maybe_msg {
+                        self.process_metadata_message(msg);
+                    } else {
+                        // If the metadata channel closed unexpectedly, keep going; enrichment stays best-effort
+                        debug!("NRI metadata channel closed");
+                    }
+                }
+
+                // Monitor NRI plugin lifecycle when active
+                result = async {
+                    if let Some(done_rx) = &mut self.nri_join_done {
+                        Some(done_rx.await)
+                    } else {
+                        None
+                    }
+                } => {
+                    if let Some(join_result) = result {
+                        match join_result {
+                            Ok(Ok(())) => {
+                                // Clean shutdown of NRI; continue processing without enrichment
+                                info!("NRI plugin exited cleanly");
+                                self.nri = None;
+                                self.nri_join_done = None;
+                            }
+                            Ok(Err(e)) => {
+                                error!("NRI plugin failed: {}", e);
+                                // Propagate error to task_completion_handler as required by spec
+                                return Err(e);
+                            }
+                            Err(recv_err) => {
+                                // oneshot channel dropped; treat as non-fatal
+                                debug!("NRI join result channel dropped: {}", recv_err);
+                                self.nri = None;
+                                self.nri_join_done = None;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::builder::{Int32Builder, Int64Builder};
+    use arrow_schema::Field;
+
+    fn make_input_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("start_time", DataType::Int64, false),
+            Field::new("pid", DataType::Int32, false),
+            Field::new("process_name", DataType::Utf8, true),
+            Field::new("cgroup_id", DataType::Int64, false),
+        ]))
+    }
+
+    fn make_simple_batch(schema: SchemaRef, cgroups: &[i64]) -> RecordBatch {
+        let mut start_b = Int64Builder::with_capacity(cgroups.len());
+        let mut pid_b = Int32Builder::with_capacity(cgroups.len());
+        let mut proc_b = StringBuilder::with_capacity(cgroups.len(), cgroups.len() * 8);
+        let mut cg_b = Int64Builder::with_capacity(cgroups.len());
+        for (i, cg) in cgroups.iter().enumerate() {
+            start_b.append_value(123);
+            pid_b.append_value(i as i32);
+            proc_b.append_value(format!("p{}", i));
+            cg_b.append_value(*cg);
+        }
+        let arrays: Vec<ArrayRef> = vec![
+            Arc::new(start_b.finish()),
+            Arc::new(pid_b.finish()),
+            Arc::new(proc_b.finish()),
+            Arc::new(cg_b.finish()),
+        ];
+        RecordBatch::try_new(schema, arrays).unwrap()
+    }
+
+    #[test]
+    fn test_schema_appended_fields() {
+        let schema = make_input_schema();
+        let (rx, tx) = (mpsc::channel(1).1, mpsc::channel(1).0); // dummy
+        let task = NRIEnrichRecordBatchTask::new(rx, tx, schema.clone());
+        let out = task.schema();
+        assert_eq!(out.fields().len(), schema.fields().len() + ENRICH_FIELDS.len());
+        let names: Vec<_> = out.fields().iter().map(|f| f.name().clone()).collect();
+        assert!(names.ends_with(&[
+            "pod_name".to_string(),
+            "pod_namespace".to_string(),
+            "pod_uid".to_string(),
+            "container_name".to_string(),
+            "container_id".to_string(),
+        ]));
+        for name in [
+            "pod_name",
+            "pod_namespace",
+            "pod_uid",
+            "container_name",
+            "container_id",
+        ] {
+            let f = out.field(out.fields().len() - ENRICH_FIELDS.len() + names
+                .iter()
+                .rev()
+                .position(|n| n == name)
+                .unwrap());
+            assert!(f.is_nullable());
+        }
+    }
+
+    #[test]
+    fn test_process_metadata_map_updates() {
+        let schema = make_input_schema();
+        let (rx, tx) = (mpsc::channel(1).1, mpsc::channel(1).0); // dummy
+        let mut task = NRIEnrichRecordBatchTask::new(rx, tx, schema);
+
+        // Use a known directory for inode: root "/" should exist
+        let inode = fs::metadata("/").unwrap().ino();
+        let meta = ContainerMetadata {
+            container_id: "abc".into(),
+            pod_name: "p".into(),
+            pod_namespace: "ns".into(),
+            pod_uid: "uid".into(),
+            container_name: "c".into(),
+            cgroup_path: "/".into(),
+            pid: None,
+            labels: HashMap::new(),
+            annotations: HashMap::new(),
+        };
+
+        task.process_metadata_message(MetadataMessage::Add("abc".into(), meta.clone()));
+        assert_eq!(task.container_to_inode.get("abc").copied(), Some(inode));
+        assert!(task.inode_to_metadata.get(&inode).is_some());
+
+        task.process_metadata_message(MetadataMessage::Remove("abc".into()));
+        assert!(task.container_to_inode.get("abc").is_none());
+        assert!(task.inode_to_metadata.get(&inode).is_none());
+    }
+
+    #[test]
+    fn test_enrich_batch_known_unknown() {
+        let schema = make_input_schema();
+        let (rx, tx) = (mpsc::channel(1).1, mpsc::channel(1).0); // dummy
+        let mut task = NRIEnrichRecordBatchTask::new(rx, tx, schema.clone());
+
+        // Prepare mapping for inode 42
+        let cm = ContainerMetadata {
+            container_id: "cont-1".into(),
+            pod_name: "pod-a".into(),
+            pod_namespace: "ns-a".into(),
+            pod_uid: "uid-a".into(),
+            container_name: "c-a".into(),
+            cgroup_path: "x".into(),
+            pid: None,
+            labels: HashMap::new(),
+            annotations: HashMap::new(),
+        };
+        task.inode_to_metadata.insert(42, cm);
+
+        // Build batch with cgroup ids [42, 7]
+        let batch = make_simple_batch(schema, &[42, 7]);
+        let enriched = task.enrich_batch(&batch).unwrap();
+        assert_eq!(enriched.num_columns(), batch.num_columns() + ENRICH_FIELDS.len());
+        assert_eq!(enriched.num_rows(), 2);
+
+        use arrow_array::StringArray;
+        let pod_name = enriched
+            .column(enriched.num_columns() - ENRICH_FIELDS.len())
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let pod_ns = enriched
+            .column(enriched.num_columns() - ENRICH_FIELDS.len() + 1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let pod_uid = enriched
+            .column(enriched.num_columns() - ENRICH_FIELDS.len() + 2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let container_name = enriched
+            .column(enriched.num_columns() - ENRICH_FIELDS.len() + 3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let container_id = enriched
+            .column(enriched.num_columns() - ENRICH_FIELDS.len() + 4)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+
+        // Row 0 has metadata
+        assert_eq!(pod_name.value(0), "pod-a");
+        assert_eq!(pod_ns.value(0), "ns-a");
+        assert_eq!(pod_uid.value(0), "uid-a");
+        assert_eq!(container_name.value(0), "c-a");
+        assert_eq!(container_id.value(0), "cont-1");
+
+        // Row 1 should be nulls
+        assert!(pod_name.is_null(1));
+        assert!(pod_ns.is_null(1));
+        assert!(pod_uid.is_null(1));
+        assert!(container_name.is_null(1));
+        assert!(container_id.is_null(1));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_resolve_cgroup_inode_best_effort() {
+        // Try to resolve current process cgroup path if possible
+        let contents = fs::read_to_string("/proc/self/cgroup").unwrap_or_default();
+        let mut cg_path: Option<String> = None;
+        for line in contents.lines() {
+            let parts: Vec<&str> = line.split(':').collect();
+            if parts.len() >= 3 && parts[0] == "0" {
+                cg_path = Some(parts[2].to_string());
+                break;
+            }
+        }
+        if let Some(path) = cg_path {
+            // Not asserting equality with bpf here, just ensure it doesn't error
+            let _ = resolve_cgroup_inode(&path);
+        }
+    }
+}
+


### PR DESCRIPTION
This PR integrates NRI container metadata into the collector metrics pipeline and adds end‑to‑end validation.

Key changes:
- Add NRIEnrichRecordBatchTask between timeslot/trace and Parquet writer
- Maintain cgroup inode → ContainerMetadata map via NRI (stat cgroup path)
- Append nullable columns to output schema: pod_name, pod_namespace, pod_uid, container_name, container_id
- Best‑effort behavior when NRI unavailable; propagate plugin errors via task_completion_handler
- Unit tests for schema, mapping, inode resolution, and enrichment
- Helm chart: mount /var/run into collector for NRI socket access
- CI: ensure enrichment columns exist; add NRI E2E job that deploys a pod and asserts:
  - pod_name == nri-enrichment-test
  - container_name == tester
  - process_name contains sleep
  - pod_namespace == default

Context: Sub-issue of overall NRI integration effort.
