### PR TITLE
Add helm chart support for running on SELinux enabled systems

### DIFF
--- a/charts/collector/Chart.yaml
+++ b/charts/collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: collector
 description: A Helm chart for the Unvariance Collector, an eBPF-based tool for collecting memory subsystem metrics
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.1.0"
 keywords:
   - ebpf

--- a/charts/collector/README.md
+++ b/charts/collector/README.md
@@ -125,6 +125,35 @@ securityContext:
   privileged: true
 ```
 
+To run on SELinux enabled systems, SELinux type and level must have
+sufficient privileges to interact with eBPF. SELinux is by default enabled
+on Fedora-based systems. See [Getting started with SELinux](https://docs.fedoraproject.org/en-US/quick-docs/selinux-getting-started/)
+in the Fedora Documentation. The default configuration allows to run with
+standard SELinux groups, and we recommend to keep it as is even on systems
+where SELinux is not enabled.
+
+More on [What is the spc_t container type, and why didn't we just run as unconfined_t?](https://danwalsh.livejournal.com/74754.html)
+
+```yaml
+podSecurityContext:
+  seLinuxOptions:
+    level: s0
+    type: spc_t
+```
+
+On systems where SELinux is not enabled, the extra POD Security Context
+options doesn't make any harm, but if you just would like to remove the
+seLinuxOptions set podSecurityContext to an empty {}.
+
+```yaml
+podSecurityContext: {}  # Empty POD securityContext
+## I have manually removed the seLinuxOptions as they are not relevant for
+## our systems. 2025-09-22 I. N. Cognito
+#  seLinuxOptions:
+#    level: s0
+#    type: spc_t
+```
+
 ### Node Selection
 
 You can customize which nodes the collector runs on using standard Kubernetes node selection:

--- a/charts/collector/templates/collector.yaml
+++ b/charts/collector/templates/collector.yaml
@@ -61,6 +61,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: nri-init
           image: "{{ .Values.nri.init.image.repository }}:{{ .Values.nri.init.image.tag }}"

--- a/charts/collector/values.yaml
+++ b/charts/collector/values.yaml
@@ -110,6 +110,12 @@ podAnnotations: {}
 # Pod labels
 podLabels: {}
 
+# POD Security context - allow running on SELinux enabled systems (e.g. RHEL, Fedora etc.)
+podSecurityContext:
+  seLinuxOptions:
+    level: s0
+    type: spc_t  # Running as SuperPrivilegedContainer - see container securityContext for reduction of kernel capabilities
+
 # Additional environment variables
 extraEnv: []
 


### PR DESCRIPTION
This pull-request implements the first part of #171, however I am unsure how the test-part should be implemented, as it would require testing in a SELinux enabled VM. Further I am unsure about how to improve the error messages. The code paths which are denied on SELinux enabled systems when blocked by SELinux whould somehow be checked to see if they fail, and then add instructions to ensure that one runs as root with sufficient privileges and SELinux correctly configured.